### PR TITLE
Filter out articles published more than 48 hours ago from myFT recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .editorconfig
 .eslintrc.js
 package-lock.json
+/public

--- a/server/lib/transform-myft-data.js
+++ b/server/lib/transform-myft-data.js
@@ -18,6 +18,19 @@ const removeDuplicateArticles = (articles, article) => {
 	return alreadyContainsArticle ? articles : articles.concat(article);
 };
 
+const removeOldArticles = (article) => {
+	const ONE_HOUR = 3600000;
+	if (!article.firstPublishedDate) {
+		return false;
+	}
+	const firstPublishedDate = new Date(article.firstPublishedDate);
+	if (Number.isNaN(firstPublishedDate.getTime())) {
+		return false; // invalid date
+	}
+	const notBefore = new Date(Date.now() - 48 * ONE_HOUR);
+	return firstPublishedDate > notBefore;
+};
+
 const orderByDate = (articleOne, articleTwo) => new Date(articleTwo.publishedDate) - new Date(articleOne.publishedDate);
 
 const removeHeadshots = article => {
@@ -44,6 +57,7 @@ const extractArticlesFromConcepts = (data) => {
 	data.articles = data.followedConcepts
 		.filter(removeEmptyConcepts)
 		.reduce(flattenConceptsToArticles, [])
+		.filter(removeOldArticles)
 		.reduce(removeDuplicateArticles, [])
 		.sort(orderByDate)
 		.slice(0, 7)
@@ -65,5 +79,7 @@ const doesUserFollowConcepts = (followedConcepts) => {
 
 module.exports = {
 	doesUserFollowConcepts,
-	extractArticlesFromConcepts
+	extractArticlesFromConcepts,
+	removeOldArticles, // FIXME - This is exported only for the sake of being unit tested. The unit under test should
+	                   // instead be `extractArticlesFromConcepts()` and this export should be removed.
 };

--- a/server/lib/transform-myft-data.js
+++ b/server/lib/transform-myft-data.js
@@ -80,6 +80,6 @@ const doesUserFollowConcepts = (followedConcepts) => {
 module.exports = {
 	doesUserFollowConcepts,
 	extractArticlesFromConcepts,
-	removeOldArticles, // FIXME - This is exported only for the sake of being unit tested. The unit under test should
-	                   // instead be `extractArticlesFromConcepts()` and this export should be removed.
+	removeOldArticles, /* FIXME - This is exported only for the sake of being unit tested. The unit under test should
+	                      instead be `extractArticlesFromConcepts()` and this export should be removed. */
 };

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -13,19 +13,15 @@ const uniqueIds = (listName, [...arrays]) => {
 	return [...set].length === arrays.reduce((tot, obj) => tot + obj[listName].length, 0);
 };
 
+let rawData = {};
+sinon.stub(middleware, 'getContent').callsFake((req, res, next) => next());
+sinon.stub(middleware, 'getRecommendations').callsFake((req, res, next) => {
+	res.locals.recommendations = rawData;
+	next();
+});
+const app = require('../server/app');
+
 describe('lure e2e', () => {
-	let app;
-	let rawData = {};
-	before(() => {
-		sinon.stub(middleware, 'getContent').callsFake((req, res, next) => next());
-		sinon.stub(middleware, 'getRecommendations').callsFake((req, res, next) => {
-			res.locals.recommendations = rawData;
-			next();
-		});
-		app = require('../server/app');
-
-	});
-
 	after(() => {
 		middleware.getContent.restore();
 		middleware.getRecommendations.restore();

--- a/test/lib/transform-myft-data.spec.js
+++ b/test/lib/transform-myft-data.spec.js
@@ -1,0 +1,46 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const transformMyFTData = require('../../server/lib/transform-myft-data.js');
+const subject = transformMyFTData.removeOldArticles;
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+describe('transformMyFTData', () => {
+	describe('removeOldArticles()', () => {
+		it('should return FALSE if an article does not have a `firstPublishedDate` field', () => {
+			const article = {};
+			expect(subject(article)).to.be.false;
+		});
+
+		it('should return FALSE if an article has an invalid `firstPublishedDate` field', () => {
+			const article = { firstPublishedDate: 'invalid date' };
+			expect(subject(article)).to.be.false;
+		});
+
+		it('should return TRUE if an article was published less than 48 hours ago', () => {
+			const fakeNow = new Date('2018-01-15');
+			const recentArticles = [
+				{ firstPublishedDate: (new Date(fakeNow.getTime())) },
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 1 * ONE_HOUR)) },
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 10 * ONE_HOUR)) },
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 47 * ONE_HOUR)) },
+			];
+			const clock = sinon.useFakeTimers(fakeNow.getTime());
+			recentArticles.forEach(article => expect(subject(article)).to.be.true);
+			clock.restore();
+		});
+
+		it('should return FALSE if an article was published more than 48 hours ago', () => {
+			const fakeNow = new Date('2018-01-15');
+			const oldArticles = [
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 49 * ONE_HOUR)) },
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 100 * ONE_HOUR)) },
+				{ firstPublishedDate: (new Date(fakeNow.getTime() - 200 * ONE_HOUR)) },
+			];
+			const clock = sinon.useFakeTimers(fakeNow.getTime());
+			oldArticles.forEach(article => expect(subject(article)).to.be.false);
+			clock.restore();
+		});
+	});
+});

--- a/test/signals/myft-recommendations.spec.js
+++ b/test/signals/myft-recommendations.spec.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const fetchMock = require('fetch-mock');
+
 const sandbox = sinon.sandbox.create();
 const stubs = {
 	fetch: sandbox.stub(),
@@ -18,6 +20,10 @@ let params;
 
 
 describe('myFT Recommendations', () => {
+
+	before(() => fetchMock.get('*', { data: { user: {}}}));
+
+	after(() => fetchMock.restore());
 
 	beforeEach(() => {
 		stubs.fetchres.json.returns({ data: {user: {followed: []}}});


### PR DESCRIPTION
Filter out articles published more than 48 hours ago from myFT recommendations

**Unrelated changes:**
* Added `/public` to `.gitignore`
* Prevented some tests from issueing actual HTTP requests

[Trello](https://trello.com/c/qWSfhaRW/812-filter-out-articles-published-more-than-48-hours-ago-from-myft-recommendations)