### PR TITLE
Support for x-teaser formats

### DIFF
--- a/server/lib/get-related-content.js
+++ b/server/lib/get-related-content.js
@@ -8,8 +8,9 @@ const getTrackablePredicate = concept => {
 	return ['about', 'isPrimarilyClassifiedBy'].includes(predicate) ? predicate : 'brand';
 };
 
-module.exports = (concept, count, parentContentId, news) => {
+module.exports = (concept, count, parentContentId, news, teaserFormat = 'n') => {
 
+	const teaserProps = teaserFormat === 'x' ? ['id', 'teaser.*'] : TEASER_PROPS;
 	let query;
 
 	if (typeof news === 'boolean') {
@@ -41,7 +42,7 @@ module.exports = (concept, count, parentContentId, news) => {
 	}
 
 	return es.search({
-		_source: TEASER_PROPS,
+		_source: teaserProps,
 		query,
 		size: count + 1
 	}, 500)

--- a/server/middleware/handle-options.js
+++ b/server/middleware/handle-options.js
@@ -8,6 +8,7 @@ module.exports = (req, res, next) => {
 	res.locals.edition = ['uk', 'international'].includes(req.get('ft-edition')) ? req.get('ft-edition') : undefined;
 	res.locals.userId = req.query.userId;
 	res.locals.secureSessionToken = req.get('FT-Session-s-Token') || req.cookies.FTSession_s;
+	res.locals.teaserFormat = req.query.format ? req.query.format : 'n';
 
 	next();
 };

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -2,14 +2,14 @@ const getMostRelatedConcepts = require('../lib/get-most-related-concepts');
 const getRelatedContent = require('../lib/get-related-content');
 const {RIBBON_COUNT, ONWARD_COUNT} = require('../constants');
 
-module.exports = async (content, {locals: {slots}}) => {
+module.exports = async (content, {locals: {slots, teaserFormat}}) => {
 	const concepts = getMostRelatedConcepts(content);
 
 	if (!concepts) {
 		return {};
 	}
 
-	const related = await getRelatedContent(concepts[0], ONWARD_COUNT, content.id);
+	const related = await getRelatedContent(concepts[0], ONWARD_COUNT, content.id, null, teaserFormat);
 
 	const response = {};
 

--- a/test/lib/get-related-content.spec.js
+++ b/test/lib/get-related-content.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const es = require('@financial-times/n-es-client');
+const TEASER_PROPS = require('@financial-times/n-teaser').esQuery;
 const constants = require('../../server/constants');
 const subject = require('../../server/lib/get-related-content');
 const sinon = require('sinon');
@@ -65,6 +66,18 @@ describe('get related content', () => {
 					}
 				]
 			}
+		});
+	});
+
+	describe('teaser formats', () => {
+		it('requests n-teaser format by default', async () => {
+			await subject({id: 'concept-id', predicate: 'about'}, 3, 'parent-id');
+			expect(es.search.args[0][0]['_source']).to.deep.equal(TEASER_PROPS);
+		});
+
+		it('requests x-teaser format when specified', async () => {
+			await subject({id: 'concept-id', predicate: 'about'}, 3, 'parent-id', null, 'x');
+			expect(es.search.args[0][0]['_source']).to.deep.equal(['id', 'teaser.*']);
 		});
 	});
 

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -73,6 +73,7 @@ describe('related-content signal', () => {
 				});
 		});
 
+		it('requests teasers in x-format if specified', () => {
 			return subject({
 				id: 'parent-id',
 				curatedRelatedContent: [],
@@ -80,9 +81,9 @@ describe('related-content signal', () => {
 					predicate: 'http://www.ft.com/ontology/annotation/about',
 					id: 0
 				}]
-			}, {locals: {slots: {onward: true}}})
+			}, {locals: {slots: {onward: true}, teaserFormat: 'x'}})
 				.then(() => {
-					expect(stubs.getRelatedContent.args[0][3]).to.eql('x');
+					expect(stubs.getRelatedContent.args[0][4]).to.eql('x');
 				});
 		});
 	});


### PR DESCRIPTION
Adds an optional parameter of `?format=x` to return ES results using the `teaser.*` property.

**By default, the responses will still return properties required by n-teaser. So this is non-breaking.**

Enables us to upgrade the onward journey component in next-article.

Also refactors some of the tests.