### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "n-health": "3.3.0"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "3.4.2",
+    "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-heroku-tools": "^8.0.0",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.