### PR TITLE
Add Snyk to Project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
       - run:
           name: shared-helper / helper-install-puppeteer-deps
           command: bash .circleci/shared-helpers/helper-install-puppeteer-deps
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/next-lure-api
       - run:
           name: Deploy to production
           command: make deploy

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
     "prepush": "make verify -j3",
-    "heroku-postbuild": "make heroku-postbuild"
+    "heroku-postbuild": "make heroku-postbuild",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "repository": {
     "type": "git",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-heroku-tools": "^8.0.0",
+    "@financial-times/n-test": "^1.13.2",
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "eslint": "^5.6.0",
@@ -46,8 +48,8 @@
     "proxyquire": "^2.1.0",
     "sinon": "^6.3.4",
     "sinon-chai": "^3.2.0",
+    "snyk": "^1.167.0",
     "supertest": "^3.3.0",
-    "supertest-as-promised": "^4.0.2",
-    "@financial-times/n-test": "^1.13.2"
+    "supertest-as-promised": "^4.0.2"
   }
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our app repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365