### PR TITLE
add graphiteName field to n-express options

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const healthchecks = require('./healthchecks');
 
 const app = express({
 	systemCode: 'next-lure-api',
+	graphiteName: 'lure-api',
 	withFlags: true,
 	healthChecks: healthchecks.checks
 });


### PR DESCRIPTION
See financial-times/n-express#563 for details.

This change requires n-express@19.22 to work but can be safely merged without it