### PR TITLE
Upgrade n-teaser to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@financial-times/n-es-client": "1.7.1",
     "@financial-times/n-express": "19.21.4",
     "@financial-times/n-logger": "6.1.0",
-    "@financial-times/n-teaser": "4.15.1",
+    "@financial-times/n-teaser": "6.0.0",
     "cookie-parser": "^1.4.3",
     "fetchres": "1.7.2",
     "ft-poller": "^3.0.1",


### PR DESCRIPTION
This was released as part of the origami breaking change. 🐿 v2.12.5