### PR TITLE
Update node 8 to 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,10 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8.15.0-browsers
-
-  container_config_lambda_node8: &container_config_lambda_node8
-    working_directory: ~/project/build
-    docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: circleci/node:10.18.0-browsers
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +55,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +88,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -109,7 +104,7 @@ jobs:
           destination: test-results
 
   provision:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -122,7 +117,7 @@ jobs:
           command: make test-review-app
 
   deploy:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Financial-Times/next-lure-api/issues"
   },
   "engines": {
-    "node": "8.15.0"
+    "node": "10.18.0"
   },
   "homepage": "https://github.com/Financial-Times/next-lure-api#readme",
   "dependencies": {


### PR DESCRIPTION
- update node 8 to 10
- modify a reference `container_config_node8` => `container_config_node`
it doesn't need to modify everytime when node version changed
- delete a reference `container_config_lambda_node8`
because it was not used anywhere

 🐿 v2.12.3