### PR TITLE
Upgrade n-es-client 1.8.0 -> 3.0.0 (Elasticsearch v7 cluster)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Financial-Times/next-lure-api#readme",
   "dependencies": {
     "@financial-times/n-concept-ids": "1.3.0",
-    "@financial-times/n-es-client": "Financial-Times/n-es-client#make-requests-to-next-elasticsearch-v7-gslb-ft-com",
+    "@financial-times/n-es-client": "3.0.0",
     "@financial-times/n-express": "21.0.7",
     "@financial-times/n-logger": "6.1.0",
     "@financial-times/n-teaser": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Financial-Times/next-lure-api#readme",
   "dependencies": {
     "@financial-times/n-concept-ids": "1.3.0",
-    "@financial-times/n-es-client": "1.8.0",
+    "@financial-times/n-es-client": "Financial-Times/n-es-client#make-requests-to-next-elasticsearch-v7-gslb-ft-com",
     "@financial-times/n-express": "21.0.7",
     "@financial-times/n-logger": "6.1.0",
     "@financial-times/n-teaser": "6.0.0",


### PR DESCRIPTION
This PR changes the version of `n-es-client` to GitHub branch [`make-requests-to-next-elasticsearch-v7-gslb-ft-com`](https://github.com/Financial-Times/n-es-client/tree/make-requests-to-next-elasticsearch-v7-gslb-ft-com) so that all of its Elasticsearch requests are directed to the new Elasticsearch v7 cluster.

Once all apps that make Elasticsearch requests via `n-es-client` have been verified as working then a new major version of that package will be released and this PR updated to instead use that.