### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbook.md
+++ b/runbook.md
@@ -1,82 +1,114 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # lure-api
+
 This api is used to power the onward journey components at the top and bottom of the article page
 
+## Code
+
+next-lure-api
+
 ## Primary URL
+
 https://www.ft.com/lure
 
-## Delivered By
-customer-products-content-discovery
-
-## Supported By
-customer-products-ops-cops
-
 ## Service Tier
+
 Bronze
 
 ## Lifecycle Stage
+
 Production
 
-## Known About By
-- thurston.tye
-
 ## Host Platform
+
 heroku
 
 ## Architecture
-This app is hit by next-article client side and provides related content from elastic search for onward journeys. 
+
+This app is hit by next-article client side and provides related content from elastic search for onward journeys.
 
 ## Contains Personal Data
+
 No
 
 ## Contains Sensitive Data
+
 No
 
-## Dependencies
-- next-esinterface
+## Can Download Personal Data
 
+No
+
+## Can Contact Individuals
+
+No
 
 ## Failover Architecture Type
+
 ActiveActive
 
 ## Failover Process Type
+
 Manual
 
 ## Failback Process Type
+
 PartiallyAutomated
 
 ## Failover Details
+
 Failover is for the whole of FT.com, rather than just for this app. Instructions for how to fail over FT.com are available [here in the Customer Products wiki](https://customer-products.in.ft.com/wiki/Failing-over-FT.com)
 
 ## Data Recovery Process Type
+
 NotApplicable
 
 ## Data Recovery Details
+
 NotApplicable
 
 ## Release Process Type
+
 FullyAutomated
 
 ## Rollback Process Type
+
 Manual
 
 ## Release Details
+
 This app is hosted on Heroku and released using Circle CI.
 Rollback is done manually on Heroku or Github. See [the guide on the wiki](https://customer-products.in.ft.com/wiki/How-does-deploying-our-Heroku-apps-work%3F) for instructions on how to deploy or roll back changes on Heroku.
 
+## Heroku Pipeline Name
+
+https://dashboard.heroku.com/pipelines/601193e7-fe09-4234-96a7-c9816a6248ea
+
 ## Key Management Process Type
+
 PartiallyAutomated
 
 ## Key Management Details
+
 You can read about how to rotate an AWS key [over on the Customer Products Wiki](https://customer-products.in.ft.com/wiki/Rotating-AWS-Keys)
 See the Customer Products [key management and troubleshooting wiki page](https://customer-products.in.ft.com/wiki/Key-Management-and-Troubleshooting)
 
-## Healthchecks
-- ft-next-lure-api-eu.herokuapp.com-https
-- ft-next-lure-api-us.herokuapp.com-https
+<!-- Placeholder - remove HTML comment markers to activate
+## Monitoring
+Enter descriptive text satisfying the following:
+Details of any monitoring this system has.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## First Line Troubleshooting
-- check dyno health on heroku
-- check elastic search is working
+
+*   check dyno health on heroku
+*   check elastic search is working
 
 ## Second Line Troubleshooting
-- check splunk `index=heroku search="*lure-api*"`
+
+*   check splunk `index=heroku search="*lure-api*"`


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/next-lure-api/blob/runbook-no-relationships-2021-03-19/runbook.md) file has been automatically regenerated from the Biz Ops data for the **next-lure-api** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **next-lure-api** system in [Biz Ops](https://biz-ops.in.ft.com/System/next-lure-api).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
