### PR TITLE
Tweak fallback logic for most related concepts

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -12,7 +12,8 @@ module.exports = {
 			'a31c3c62-b936-11e7-8c12-5661783e5589', // smoke tests example article id
 			'b0d8e4fe-10ff-11e5-8413-00144feabdc0', // intlTopStories list id
 			'658368f2-b41e-11e7-82e7-100554b68858', // README.md:3 - image of fishing fly
-			'9b40e89c-e87b-3d4f-b72c-2cf7511d2146' // news genre id
+			'9b40e89c-e87b-3d4f-b72c-2cf7511d2146', // news genre id
+			'601193e7-fe09-4234-96a7-c9816a6248ea', // runbook.md
 		]
 	}
 };

--- a/server/lib/get-most-related-concepts.js
+++ b/server/lib/get-most-related-concepts.js
@@ -8,14 +8,14 @@ module.exports = content => {
 	const mostRelatedConcepts = [
 		displayTag,
 		content.annotations.find(annotation => annotation.predicate === 'http://www.ft.com/ontology/annotation/about'),
-		content.annotations.find(annotation => annotation.predicate === 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy')
+		content.annotations.find(annotation => annotation.predicate === 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy'),
+		content.annotations.find(annotation => annotation.predicate === 'http://www.ft.com/ontology/implicitlyAbout'),
+		content.annotations.find(
+			annotation => annotation.predicate === 'http://www.ft.com/ontology/classification/isClassifiedBy'
+			&& annotation.directType === 'http://www.ft.com/ontology/product/Brand'
+		)
 	]
 		.filter(concept => !!concept);
 
-	if (mostRelatedConcepts.length < 2) {
-		if(content.brandConcept && !mostRelatedConcepts.find(concept => concept.id === content.brandConcept.id)) {
-			mostRelatedConcepts.push(content.brandConcept);
-		}
-	}
 	return mostRelatedConcepts.length ? mostRelatedConcepts : undefined;
 };

--- a/test/lib/get-most-related-concepts.spec.js
+++ b/test/lib/get-most-related-concepts.spec.js
@@ -2,41 +2,62 @@ const {expect} = require('chai');
 const subject = require('../../server/lib/get-most-related-concepts');
 
 describe('get most related concepts', () => {
-	it('use about and isPrimarilyClassifiedBy by default', () => {
+	it('use about, isPrimarilyClassifiedBy and implicitlyAbout by default', () => {
 		const result = subject({
-			annotations: [{
-				predicate: 'http://www.ft.com/ontology/annotation/about',
-				id: 0
-			}, {
-				predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
-				id: 1
-			}]
+			annotations: [
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/product/Brand',
+					id: 3,
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/implicitlyAbout',
+					id: 2,
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
+					id: 1,
+				},{
+					predicate: 'http://www.ft.com/ontology/annotation/about',
+					id: 0,
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				}
+			]
 		});
 		expect(result[0].id).to.equal(0);
 		expect(result[1].id).to.equal(1);
-	});
-
-	it('fallback to brand if either preferred annotation is missing', () => {
-		const result = subject({
-			annotations: [{
-				predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
-				id: 1
-			}],
-			brandConcept: {
-				id: 2,
-				predicate: 'whatevs'
-			}
-		});
-		expect(result[0].id).to.equal(1);
-		expect(result[1].id).to.equal(2);
+		expect(result[2].id).to.equal(2);
+		expect(result[3].id).to.equal(3);
+		expect(result.length).to.equal(4);
 	});
 
 	it('handle case where only one preferred annotation is present', () => {
 		const result = subject({
-			annotations: [{
-				predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
-				id: 1
-			}]
+			annotations: [
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
+					id: 1
+				}
+			]
 		});
 		expect(result[0].id).to.equal(1);
 		expect(result.length).to.equal(1);
@@ -44,24 +65,27 @@ describe('get most related concepts', () => {
 
 	it('handle case where no preferred annotations are present', () => {
 		const result = subject({
-			annotations: []
+			annotations: [
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				},
+				{
+					predicate: 'http://www.ft.com/ontology/classification/isClassifiedBy',
+					directType: 'http://www.ft.com/ontology/Topic',
+					id: 'should-be-ignored',
+				},
+			]
 		});
 		expect(result).to.be.undefined;
 	});
 
-	it('handle case where no about, and isPrimarilyClassifiedBy by the brand', () => {
+	it('handle case where no annotations are present', () => {
 		const result = subject({
-			annotations: [{
-				predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
-				id: 1
-			}],
-			brandConcept: {
-				predicate: 'http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy',
-				id: 1
-			}
+			annotations: []
 		});
-		expect(result[0].id).to.equal(1);
-		expect(result.length).to.equal(1);
+		expect(result).to.be.undefined;
 	});
 
 	it('handle case where content has no annotations', () => {


### PR DESCRIPTION
It now uses the implicitlyAbout predicate as the main fallback
for most scenarios. But also keeps the original brand fallback
 in case that was important for some edge case but without
using next-elastic's deprecated brandConcept property.