### PR TITLE
Rename lureBrandOnwardSlot flag to onwardJourneyTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ JSON response on which one or more of the following keys - `rhr`, `onward`, `int
 
 May (in v1, for backwards compatibility) return an array of objects like the above
 
+### Flags
 
-### Plans
-- All requests may send a content uuid or concept for contextual targeting
-- Requests should include feature flags and any ab tests/cohorts the user is in
-- Requests may include the user uuid for more personalised targeting
-- Request may specify things to exclude from the space of possible recommendations
+There is a permanent mutlivariate test (MVT) flag called `onwardJourneyTests` that's used for testing new iterations of the onward journey on articles. Ideally we shouldn't be running more than one A/B or MVT test at a time because this makes test results confusing. The idea is to reuse the same flags for all tests and it will feel wrong to have multiple flags in use within the codebase.

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -15,7 +15,7 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		topic = getRelatedContent(topicConcept, count, content.id);
 	}
 
-	if (flags.lureBrandOnwardSlot) {
+	if (flags.onwardJourneyTests) {
 		const brandConcept = getBrandConcept(content);
 		// In some cases, such as for Podcast episodes, the displayConcept is set to be a Brand
 		const isDuplicate = brandConcept && topicConcept && topicConcept.id === brandConcept.id;
@@ -35,11 +35,11 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		ribbon = brand;
 		onward = brand;
 	} else if (topic && brand) {
-		if (flags.lureBrandOnwardSlot === 'brandRibbon') {
+		if (flags.onwardJourneyTests === 'variant1') {
 			ribbon = brand;
 			onward = topic;
 			onward2 = brand;
-		} else if (flags.lureBrandOnwardSlot) {
+		} else if (flags.onwardJourneyTests === 'variant2') {
 			ribbon = topic;
 			onward = brand;
 			onward2 = topic;

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -129,11 +129,11 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('use brand stories when flag lureBrandOnwardSlot=brandRibbon ', () => {
+		it('use brand stories when flag onwardJourneyTests=variant1 ', () => {
 			const concept = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const content = { id: 'parent-id', annotations: [concept] };
 			const slots = {ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getRelatedContent.resolves({
 				concept,
@@ -148,7 +148,7 @@ describe('related-content signal', () => {
 	});
 
 	context('onward2 slot', () => {
-		it('doesn\`t return onward2 slot if lureBrandOnwardSlot flag is off', () => {
+		it('doesn\`t return onward2 slot if onwardJourneyTests flag is off', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id' };
@@ -184,7 +184,7 @@ describe('related-content signal', () => {
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id' };
 			const slots = {onward2: true, onward: false};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -204,12 +204,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('returns correct stories in slot (Variant: lureBrandOnwardSlot=brandRibbon)', () => {
+		it('returns correct stories in slot (Variant: onwardJourneyTests=variant1)', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -233,12 +233,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('returns correct stories in slot (Variant: lureBrandOnwardSlot=noBrandRibbon)', () => {
+		it('returns correct stories in slot (Variant: onwardJourneyTests=variant2)', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'noBrandRibbon'};
+			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -262,12 +262,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('Shift stories from onward2 slot to onward slot if the latter is empty (Variant: lureBrandOnwardSlot=brandRibbon)', () => {
+		it('Shift stories from onward2 slot to onward slot if the latter is empty (Variant: onwardJourneyTests=variant1)', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -289,12 +289,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('Shift stories from onward2 slot to onward slot if the latter is empty (Variant: lureBrandOnwardSlot=noBrandRibbon)', () => {
+		it('Shift stories from onward2 slot to onward slot if the latter is empty (Variant: onwardJourneyTests=variant2)', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true};
-			const flags = {lureBrandOnwardSlot: 'noBrandRibbon'};
+			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -321,7 +321,7 @@ describe('related-content signal', () => {
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -352,7 +352,7 @@ describe('related-content signal', () => {
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'noBrandRibbon'};
+			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -378,12 +378,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('does not unnecessarily remove duplicate content (Variant: lureBrandOnwardSlot=noBrandRibbon)', () => {
+		it('does not unnecessarily remove duplicate content (Variant: onwardJourneyTests=variant2)', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'noBrandRibbon'};
+			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
@@ -416,12 +416,12 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('does not unnecessarily remove duplicate content (Variant:lureBrandOnwardSlot=brandRibbon)', () => {
+		it('does not unnecessarily remove duplicate content (Variant:onwardJourneyTests=variant1)', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
-			const flags = {lureBrandOnwardSlot: 'brandRibbon'};
+			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);


### PR DESCRIPTION
Changing to a more generic name so we can use one flag
for all future tests without having to create a new one for
each test. It's also more discoverable in toggler.

Really we should never have more than one test at a
time as this makes test results confusing. Having a reusable flag
helps to make 2 concurrent tests feel very wrong.