### PR TITLE
Add metadata to response payload for tracking

### DIFF
--- a/server/middleware/respond.js
+++ b/server/middleware/respond.js
@@ -7,23 +7,28 @@ const finishModel = (model, defaultTitleIntro) => {
 	if (!model.concept) {
 		return Object.assign({}, {
 			title: model.title,
-			titleHref: model.titleHref
+			titleHref: model.titleHref,
+			contentSelection: model.contentSelection,
 		}, listObj);
 	}
 
 	return Object.assign({}, {
 		title:  model.title || `${defaultTitleIntro} ${model.concept.preposition} ${model.concept.prefLabel}`,
 		titleHref:  model.titleHref || model.concept.relativeUrl,
-		concept: model.concept
+		concept: model.concept,
+		contentSelection: model.contentSelection,
 	}, listObj);
 };
+
+const sum = (total, value) => total + value;
+const numItems = (slot) => slot && slot.items && slot.items.length || 0;
 
 module.exports = (_, res) => {
 	if (!res.locals.recommendations || !Object.keys(res.locals.recommendations).length) {
 		throw new createError.NotFound();
 	}
 
-	const { recommendations } = res.locals;
+	const { recommendations, flags = {} } = res.locals;
 	const response = {};
 
 	if (recommendations.ribbon) {
@@ -37,6 +42,23 @@ module.exports = (_, res) => {
 	if (recommendations.onward2) {
 		response.onward2 = finishModel(recommendations.onward2, 'More');
 	}
+
+	const numSlots = Object.keys(response).length;
+	const totalItems = Object.values(response).map(numItems).reduce(sum, 0);
+
+	// The front-end will send this data to Spoor when the Onward Journey is displayed.
+	// The front-end will also send to spoor data about which components were shown to the user.
+	response._metadata = {
+		flagState: {
+			onwardJourneyTests: flags.onwardJourneyTests || 'control',
+		},
+		numSlots,
+		totalItems,
+		contentSelection: Object.keys(response).reduce((o, k) => {
+			o[k] = response[k].contentSelection;
+			return o;
+		}, {}),
+	};
 
 	res.set('Cache-Control', res.FT_NO_CACHE);
 	if (recommendations._noCache) {

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -27,22 +27,29 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	let ribbon;
 	let onward;
 	let onward2;
+	let contentSelection = {};
 
 	if (topic && !brand) {
 		ribbon = topic;
 		onward = topic;
+		contentSelection.ribbon = contentSelection.onward = 'topic';
 	} else if (!topic && brand) {
 		ribbon = brand;
 		onward = brand;
+		contentSelection.ribbon = contentSelection.onward = 'brand';
 	} else if (topic && brand) {
 		if (flags.onwardJourneyTests === 'variant1') {
 			ribbon = brand;
 			onward = topic;
 			onward2 = brand;
+			contentSelection.ribbon = contentSelection.onward2 = 'brand';
+			contentSelection.onward = 'topic';
 		} else if (flags.onwardJourneyTests === 'variant2') {
 			ribbon = topic;
 			onward = brand;
 			onward2 = topic;
+			contentSelection.ribbon = contentSelection.onward2 = 'topic';
+			contentSelection.onward = 'brand';
 		}
 	}
 
@@ -62,6 +69,7 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 			concept: {
 				...data.concept,
 			},
+			contentSelection: contentSelection[name],
 			items: data.items.slice(0),
 		};
 	}

--- a/test/middleware/respond.spec.js
+++ b/test/middleware/respond.spec.js
@@ -38,7 +38,7 @@ describe('respond middleware', () => {
 			locals: {
 				recommendations: {
 					items: []
-				}
+				},
 			},
 			set: sinon.spy(),
 			json: () => {},
@@ -67,5 +67,44 @@ describe('respond middleware', () => {
 		subject({}, res);
 		expect(res.set.calledWith('Cache-Control', FT_NO_CACHE)).to.be.true;
 		expect(res.set.calledWith('Surrogate-Control', FT_NO_CACHE)).to.be.true;
+	});
+
+	it('adds metadata describing the payload, internal processing of content and decisions made by the service', () => {
+
+		const res = {
+			locals: {
+				recommendations: {
+					ribbon: {
+						title: 'title',
+						titleHref: '/stream/id',
+						items: [{}, {}, {}],
+						contentSelection: 'content-selection-value'
+					}
+				},
+				flags: {
+					onwardJourneyTests: 'test-flag-value',
+					decoyFlag: true,
+				}
+			},
+			set: sinon.spy(),
+			json: sinon.spy(),
+			FT_NO_CACHE,
+			FT_HOUR_CACHE,
+		};
+
+		const expected = {
+			_metadata: {
+				flagState: {
+					onwardJourneyTests: 'test-flag-value'
+				},
+				numSlots: 1,
+				totalItems: 3,
+				contentSelection: {
+					ribbon: 'content-selection-value'
+				},
+			}
+		};
+		subject({}, res);
+		expect(res.json.getCall(0).args[0]).to.deep.include(expected);
 	});
 });

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -145,6 +145,19 @@ describe('related-content signal', () => {
 				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4 ]);
 			});
 		});
+
+		it('don\'t show if no teasers', () => {
+			const concept = annotation(0, ConceptType.Topic, Predicate.about);
+			const content = { id: 'parent-id', annotations: [concept] };
+			const slots = {ribbon: true};
+			getMostRelatedConcepts.returns([concept]);
+			getRelatedContent.resolves({
+				concept,
+				items: []
+			});
+			const promise = subject(content, {locals: {slots}});
+			return expect(promise).to.eventually.eql({});
+		});
 	});
 
 	context('onward2 slot', () => {


### PR DESCRIPTION
This captures metadata about the content returned in in the payload, the flag state and the content selection strategies used.

This will be used by the [client to send contextual data to spoor][1], allowing more accurate analysis of MVT tests.

The code isn't very clean at the moment. We can return to that as part of some refactoring we need to do.

[1]: https://github.com/Financial-Times/next-article/pull/4304