### PR TITLE
Change test variant2 to behave more like a control

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -1,5 +1,24 @@
+const BOTTOM_ROW_SIZE = 4;
+
+const Count = {
+	RIBBON: 4,
+	ONWARD:  BOTTOM_ROW_SIZE * 2,
+	ONWARD2: BOTTOM_ROW_SIZE * 1,
+};
+
+const ContentSelection = {
+	TOPIC: 'topic',
+	BRAND: 'brand',
+};
+
+const TestVariant = {
+	Variant1: 'variant1',
+	Variant2: 'variant2',
+};
+
 module.exports = {
-	RIBBON_COUNT: 4,
-	ONWARD_COUNT: 8,
-	ONWARD2_COUNT: 4,
+	Count,
+	ContentSelection,
+	TestVariant,
+	BOTTOM_ROW_SIZE,
 };

--- a/server/lib/can-show-on-page.js
+++ b/server/lib/can-show-on-page.js
@@ -1,0 +1,24 @@
+function canShowRibbonOnPage (content) {
+	if (content.topper && content.topper.layout) {
+		return false;
+	}
+
+	if (Array.isArray(content.containedIn) && content.containedIn.length) {
+		return false;
+	}
+
+	return true;
+}
+
+function canShowBottomSlotOnPage (content) {
+	if (Array.isArray(content.containedIn) && content.containedIn.length) {
+		return false;
+	}
+
+	return true;
+}
+
+module.exports = {
+	canShowBottomSlotOnPage,
+	canShowRibbonOnPage,
+};

--- a/server/lib/dedupe.js
+++ b/server/lib/dedupe.js
@@ -1,0 +1,49 @@
+const copy = (a,b) => [a.slice(0), b.slice(0)];
+
+function simple (fn, a, b) {
+	const [A, B] = copy(a, b);
+	// Remove elements from B if they appear in A
+	const ids = new Set(A.map(fn));
+	return [A, B.filter(item => !ids.has(fn(item)))];
+}
+
+function advanced (fn, a, b, frameSize) {
+	const [A, B] = copy(a, b);
+
+	frameSize = frameSize ? frameSize : A.length * 10;
+
+	const score = index => (Math.floor(index / frameSize) * frameSize) + index;
+	const mapScore = (array, scoreFn) => (
+		new Map(array.map((item, index) => [fn(item), scoreFn(item, index)]))
+	);
+
+	const scoresA = mapScore(A, (_, index) => score(index));
+	const scoresB = mapScore(B, (_, index) => score(index) + (frameSize / 2));
+
+	return [
+		A.filter(item => {
+			const key = fn(item);
+			const valueB = scoresB.get(key);
+			const valueA = scoresA.get(key);
+			if (!Number.isFinite(valueB)) {
+				return true;
+			}
+			return valueA < valueB;
+		}),
+
+		B.filter(item => {
+			const key = fn(item);
+			const valueB = scoresB.get(key);
+			const valueA = scoresA.get(key);
+			if (!Number.isFinite(valueA)) {
+				return true;
+			}
+			return valueB <= valueA;
+		}),
+	];
+}
+
+module.exports = {
+	simple,
+	advanced,
+};

--- a/server/middleware/get-content.js
+++ b/server/middleware/get-content.js
@@ -11,6 +11,8 @@ module.exports = async (req, res, next) => {
 					'annotations',
 					'displayConcept',
 					'publishedDate',
+					'topper',
+					'containedIn',
 				],
 			},
 			500

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -1,10 +1,10 @@
 const getMostRelatedConcepts = require('../lib/get-most-related-concepts');
 const getBrandConcept = require('../lib/get-brand-concept');
 const getRelatedContent = require('../lib/get-related-content');
-const {RIBBON_COUNT, ONWARD_COUNT, ONWARD2_COUNT} = require('../constants');
+const {Count, ContentSelection, TestVariant} = require('../constants');
 
 async function relatedContent (content, {locals: {flags = {}, slots}}) {
-	const count = Math.max(RIBBON_COUNT, ONWARD_COUNT, ONWARD2_COUNT);
+	const count = Math.max(Count.RIBBON, Count.ONWARD, Count.ONWARD2);
 	let topic;
 	let brand;
 
@@ -32,24 +32,21 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	if (topic && !brand) {
 		ribbon = topic;
 		onward = topic;
-		contentSelection.ribbon = contentSelection.onward = 'topic';
+		contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
 	} else if (!topic && brand) {
 		ribbon = brand;
 		onward = brand;
-		contentSelection.ribbon = contentSelection.onward = 'brand';
+		contentSelection.ribbon = contentSelection.onward = ContentSelection.BRAND;
 	} else if (topic && brand) {
-		if (flags.onwardJourneyTests === 'variant1') {
+		if (flags.onwardJourneyTests === TestVariant.Variant1) {
 			ribbon = brand;
 			onward = topic;
 			onward2 = brand;
-			contentSelection.ribbon = contentSelection.onward2 = 'brand';
-			contentSelection.onward = 'topic';
-		} else if (flags.onwardJourneyTests === 'variant2') {
-			ribbon = topic;
+				contentSelection.ribbon = contentSelection.onward2 = ContentSelection.BRAND;
+				contentSelection.onward = ContentSelection.TOPIC;
 			onward = brand;
 			onward2 = topic;
-			contentSelection.ribbon = contentSelection.onward2 = 'topic';
-			contentSelection.onward = 'brand';
+		} else if (flags.onwardJourneyTests === TestVariant.Variant2) {
 		}
 	}
 
@@ -90,19 +87,19 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	// Dedupe & Trim
 	if (response.ribbon) {
 		// Ribbon is not considered when deduping
-		response.ribbon.items = response.ribbon.items.slice(0, RIBBON_COUNT);
+		response.ribbon.items = response.ribbon.items.slice(0, Count.RIBBON);
 	}
 
 	if (response.onward && response.onward2) {
 		// Dedupe two adjacent components.
-		response.onward.items = response.onward.items.slice(0, ONWARD_COUNT);
+		response.onward.items = response.onward.items.slice(0, Count.ONWARD);
 		const ids = new Set(response.onward.items.map(item => item.id));
 		// Remove items from the second component. Trim after removing duplicates.
-		response.onward2.items = response.onward2.items.filter((item) => !ids.has(item.id)).slice(0, ONWARD2_COUNT);
+		response.onward2.items = response.onward2.items.filter((item) => !ids.has(item.id)).slice(0, Count.ONWARD2);
 	} else if (response.onward) {
-		response.onward.items = response.onward.items.slice(0, ONWARD_COUNT);
+		response.onward.items = response.onward.items.slice(0, Count.ONWARD);
 	} else if (response.onward2) {
-		response.onward2.items = response.onward2.items.slice(0, ONWARD2_COUNT);
+		response.onward2.items = response.onward2.items.slice(0, Count.ONWARD2);
 	}
 
 	return response;

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -2,6 +2,7 @@ const getMostRelatedConcepts = require('../lib/get-most-related-concepts');
 const getBrandConcept = require('../lib/get-brand-concept');
 const getRelatedContent = require('../lib/get-related-content');
 const {Count, ContentSelection, TestVariant} = require('../constants');
+const { canShowBottomSlotOnPage, canShowRibbonOnPage } = require('../lib/can-show-on-page');
 
 async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	const count = Math.max(Count.RIBBON, Count.ONWARD, Count.ONWARD2);
@@ -10,6 +11,15 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 
 	const relatedConcepts = getMostRelatedConcepts(content) || [];
 	const topicConcept = relatedConcepts[0];
+
+	if (!canShowRibbonOnPage(content)) {
+		slots.ribbon = false;
+	}
+
+	if (!canShowBottomSlotOnPage(content)) {
+		slots.onward = false;
+		slots.onward2 = false;
+	}
 
 	if (topicConcept) {
 		topic = getRelatedContent(topicConcept, count, content.id);
@@ -84,7 +94,15 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		delete response.onward2;
 	}
 
-	// Dedupe & Trim
+	if (!canShowRibbonOnPage(content)) {
+		delete response.ribbon;
+	}
+
+	if (!canShowBottomSlotOnPage(content)) {
+		delete response.onward;
+		delete response.onward2;
+	}
+
 	if (response.ribbon) {
 		// Ribbon is not considered when deduping
 		response.ribbon.items = response.ribbon.items.slice(0, Count.RIBBON);

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -50,14 +50,24 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		contentSelection.ribbon = contentSelection.onward = ContentSelection.BRAND;
 	} else if (topic && brand) {
 		if (flags.onwardJourneyTests === TestVariant.Variant1) {
-			ribbon = brand;
-			onward = topic;
-			onward2 = brand;
+			if (slots.ribbon) {
+				ribbon = brand;
+				onward = topic;
+				onward2 = brand;
 				contentSelection.ribbon = contentSelection.onward2 = ContentSelection.BRAND;
 				contentSelection.onward = ContentSelection.TOPIC;
-			onward = brand;
-			onward2 = topic;
+			} else {
+				onward = brand;
+				onward2 = topic;
+				contentSelection.onward = ContentSelection.BRAND;
+				contentSelection.onward2 = ContentSelection.TOPIC;
+			}
 		} else if (flags.onwardJourneyTests === TestVariant.Variant2) {
+			ribbon = topic;
+			onward = topic;
+			onward2 = brand;
+			contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
+			contentSelection.onward2 = ContentSelection.BRAND;
 		}
 	}
 
@@ -112,15 +122,37 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	}
 
 	if (response.onward && response.onward2) {
-		// Dedupe two adjacent components.
-		const [a, b] = dedupe.simple(
-			item => item.id,
-			response.onward.items.slice(0, Count.ONWARD), // Trim BEFORE deduping
-			response.onward2.items,
-		);
-		response.onward2.items = a;
-		// Trim AFTER removing duplicates.
-		response.onward2.items = b.slice(0, Count.ONWARD2);
+		if (flags.onwardJourneyTests === TestVariant.Variant2) {
+			// Dedupe strategy:
+			// Simply remove elements from the second list (onward2)
+			// if they appear in the first list (onward).
+			// We don't use the advaned strategy which may, in some cases, remove
+			// elements from the first list if they appear in a more favourable position
+			// in the seond list. This is because the current test onward2
+			const [a, b] = dedupe.simple(
+				item => item.id,
+				response.onward.items.slice(0, Count.ONWARD + 4 /* +4 to add an extra row of results */),
+				response.onward2.items
+			);
+			response.onward.items = a;
+			//Trim onward2 AFTER removing duplicates.
+			response.onward2.items = b.slice(0, Count.ONWARD2);
+		} else {
+			const frameSize = 4;
+			// Dedupe strategy:
+			// Remove duplicate elements from either list depending where they appear in the list.
+			// eg If a duplicate item's index in A=5 and B=0, then remove it from list A.
+			// This is to avoid favouring a duplicate that is unlikely to be displayed on the front-end
+			const [a, b] = dedupe.advanced(
+				item => item.id,
+				response.onward.items.slice(0, Count.ONWARD),
+				response.onward2.items,
+				frameSize,
+			);
+			response.onward.items = a;
+			//Trim onward2 AFTER removing duplicates.
+			response.onward2.items = b.slice(0, Count.ONWARD2);
+		}
 	} else if (response.onward) {
 		response.onward.items = response.onward.items.slice(0, Count.ONWARD);
 	} else if (response.onward2) {

--- a/test/lib/can-show-on-page.spec.js
+++ b/test/lib/can-show-on-page.spec.js
@@ -1,0 +1,63 @@
+const { expect } = require('chai');
+const { canShowRibbonOnPage, canShowBottomSlotOnPage } = require('../../server/lib/can-show-on-page');
+
+describe('lib/can-show-in-slot.js', () => {
+
+	describe('canShowRibbonOnPage', () => {
+		it('happy path', () => {
+			const content = { id: 'content-id' };
+			const result = canShowRibbonOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Content has an empty topper', () => {
+			const content = { topper: {} };
+			const result = canShowRibbonOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Content has a custom Editorial topper', () => {
+			const content = { topper: { layout: 'full-bleed-offset' } };
+			const result = canShowRibbonOnPage(content);
+			expect(result).to.eql(false);
+		});
+
+		it('Content containedIn in NO ContentPackages', () => {
+			const content = { containedIn: [] };
+			const result = canShowRibbonOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Content containedIn in One ContentPackages', () => {
+			const content = { containedIn: [ {id:'content-package'} ] };
+			const result = canShowRibbonOnPage(content);
+			expect(result).to.eql(false);
+		});
+	});
+
+	describe('canShowBottomSlotOnPage', () => {
+		it('happy path', () => {
+			const content = { id: 'content-id' };
+			const result = canShowBottomSlotOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Does not matter if the content has a topper', () => {
+			const content = { topper: {} };
+			const result = canShowBottomSlotOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Content containedIn in NO ContentPackages', () => {
+			const content = { containedIn: [] };
+			const result = canShowBottomSlotOnPage(content);
+			expect(result).to.eql(true);
+		});
+
+		it('Content containedIn in One ContentPackages', () => {
+			const content = { containedIn: [ {id:'content-package'} ] };
+			const result = canShowBottomSlotOnPage(content);
+			expect(result).to.eql(false);
+		});
+	});
+});

--- a/test/lib/dedupe.spec.js
+++ b/test/lib/dedupe.spec.js
@@ -1,0 +1,179 @@
+const { expect } = require('chai');
+const { simple, advanced } = require('../../server/lib/dedupe');
+
+describe('lib/dedupe.js', () => {
+
+	describe('simple', () => {
+
+		it('do not remove element when there are no duplicates', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a'];
+			const b = ['1b', '2b', '3b', '4b', '5b'];
+			const [resultA, resultB] = simple(fn, a, b);
+			expect(resultA).to.eql(a, 'List A');
+			expect(resultB).to.eql(b, 'List B');
+		});
+
+		it('remove duplicates from second list', () => {
+			const fn = value => value;
+			const a = ['DUPLICATE', '2a', 'DUPLICATE', '4a', '5a'];
+			const b = ['DUPLICATE', 'DUPLICATE', '3b', '4b', '5b'];
+			const [resultA, resultB] = simple(fn, a, b);
+			expect(resultA).to.eql(['DUPLICATE', '2a', 'DUPLICATE', '4a', '5a'], 'List A');
+			expect(resultB).to.eql([/* removed */'3b', '4b', '5b'], 'List B');
+		});
+
+		it('identify duplicate with function', () => {
+			const fn = obj => obj.id;
+			const a = [{id: 'DUPLICATE'}, {id: '2a'}, {id: 'DUPLICATE'}, {id: '4a'}, {id: '5a'}];
+			const b = [{id: 'DUPLICATE'}, {id: 'DUPLICATE'}, {id: '3b'}, {id: '4b'}, {id: '5b'}];
+			const [resultA, resultB] = simple(fn, a, b);
+			expect(resultA).to.eql([{id:'DUPLICATE'}, {id:'2a'}, {id:'DUPLICATE'}, {id:'4a'}, {id:'5a'}], 'List A');
+			expect(resultB).to.eql([/* removed */ {id:'3b'}, {id:'4b'}, {id:'5b'}], 'List B');
+		});
+
+	});
+
+	describe('advanced', () => {
+
+		it('remove duplciates from second list when there is no frameSize argument', () => {
+			const fn = value => value;
+			const a = ['DUPLICATE-X', '2a', '3a', 'DUPLICATE-Y', '5a', '6a', 'DUPLICATE-Z', '8a'];
+			const b = ['DUPLICATE-X', 'DUPLICATE-Y', 'DUPLICATE-Z', '4b', '5b', '6b', '7b', '8b'];
+			const [resultA, resultB] = advanced(fn, a, b);
+			expect(resultA).to.eql(['DUPLICATE-X', '2a', '3a', 'DUPLICATE-Y', '5a', '6a', 'DUPLICATE-Z', '8a'], 'List A');
+			expect(resultB).to.eql(['4b', '5b', '6b', '7b', '8b'], 'List B');
+		});
+
+		it('do not remove elements when there are no duplicates and no frameSize argument', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a'];
+			const b = ['1b', '2b', '3b', '4b'];
+			const [resultA, resultB] = advanced(fn, a, b);
+			expect(resultA).to.eql(a), 'List A';
+			expect(resultB).to.eql(b, 'List B');
+		});
+
+		it('do not remove elements when there are no duplicates', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a'];
+			const b = ['1b', '2b', '3b', '4b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(a, 'List A');
+			expect(resultB).to.eql(b, 'List B');
+		});
+
+		it('remove duplicate from second list', () => {
+			const fn = value => value;
+			const a = ['DUPLICATE', '2a', '3a', '4a'];
+			const b = ['1b', '2b', '3b', 'DUPLICATE'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(a, 'List A');
+			expect(resultB).to.eql(['1b', '2b', '3b' /* removed */], 'List B');
+		});
+
+		it('identiy function', () => {
+			const fn = obj => obj.id;
+			const a = [{id:'DUPLICATE-Y'}, {id:'DUPLICATE-Z'}, {id:'3a'}, {id:'4a'}];
+			const b = [{id:'DUPLICATE-Z'}, {id:'DUPLICATE-Y'}, {id:'3b'}, {id:'4b'}];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql([{id:'DUPLICATE-Y'}, {id:'DUPLICATE-Z'}, {id:'3a'}, {id:'4a'}], 'List A');
+			expect(resultB).to.eql([/* removed, removed */ {id:'3b'}, {id:'4b'}], 'List B');
+		});
+
+		it('remove multiple duplicates from second list', () => {
+			const fn = value => value;
+			const a = ['DUPLICATE-Y', 'DUPLICATE-Z', '3a', '4a'];
+			const b = ['DUPLICATE-Z', 'DUPLICATE-Y', '3b', '4b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['DUPLICATE-Y', 'DUPLICATE-Z', '3a', '4a'], 'List A');
+			expect(resultB).to.eql([/* removed, removed */ '3b', '4b'], 'List B');
+		});
+
+		it('remove duplicate from first list when the duplicate is near the beginning of the second list', () => {
+			const fn = value => value;
+
+			const a = ['1a', '2a', '3a', 'DUPLICATE',];
+			const b = ['DUPLICATE', '2b', '3b', '4b',];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a' /* removed */], 'List A');
+			expect(resultB).to.eql(['DUPLICATE', '2b', '3b', '4b'], 'List B');
+		});
+
+		it('remove duplicates from both lists depending on the postion of the duplicate', () => {
+			const fn = value => value;
+			const a = ['DUPLICATE-Y', '2a', '3a', 'DUPLICATE-Z'];
+			const b = ['DUPLICATE-Y', 'DUPLICATE-Z', '3b', '4b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['DUPLICATE-Y', '2a', '3a', /* removed */], 'List A');
+			expect(resultB).to.eql([/* removed */ 'DUPLICATE-Z', '3b', '4b'], 'List B');
+		});
+
+		it('remove duplicate from first list when its index is larger than the frameSize', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a', 'DUPLICATE'];
+			const b = ['DUPLICATE', '2b', '3b', '4b', '5b', '6b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a', '4a', '5a' /* removed */], 'List A');
+			expect(resultB).to.eql(['DUPLICATE', '2b', '3b', '4b', '5b', '6b'], 'List B');
+		});
+
+		it('remove duplicate from the second list when both elements are outside the frame', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a', 'DUPLICATE'];
+			const b = ['1b', '2b', '3b', '4b', '5b', 'DUPLICATE'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a', '4a', '5a', 'DUPLICATE'], 'List A');
+			expect(resultB).to.eql(['1b', '2b', '3b', '4b', '5b' /* removed */], 'List B');
+		});
+
+		it('remove element from the second list when both elements are in the second frame', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', 'DUPLICATE', '11a', '12a'];
+			const b = ['1b', '2b', '3b', '4b', '5b', '6b', '7b', '8b', '9b', '10b', 'DUPLICATE', '12b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', 'DUPLICATE', '11a', '12a'], 'List A');
+			expect(resultB).to.eql(['1b', '2b', '3b', '4b', '5b', '6b', '7b', '8b', '9b', '10b', /* removed */ '12b'], 'List B');
+		});
+
+		it('remove element from the first list when both elements are in the second frame but duplicate has a higher index in the first list', () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', '10a', '11a', 'DUPLICATE'];
+			const b = ['1b', '2b', '3b', '4b', '5b', '6b', '7b', '8b', 'DUPLICATE', '10b', '11b', '12b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', '10a', '11a', /* removed */], 'List A');
+			expect(resultB).to.eql(['1b', '2b', '3b', '4b', '5b', '6b', '7b', '8b', 'DUPLICATE', '10b', '11b', '12b'], 'List B');
+		});
+
+		it('remove element from first list. duplicate is in third frame of first list, but in the second frame in the other list' , () => {
+			const fn = value => value;
+			const a = ['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', 'DUPLICATE', '11a', '12a'];
+			const b = ['1b', '2b', '3b', '4b', '5b', 'DUPLICATE', '7b', '8b', '9b', '10b', '11b', '12b'];
+			const frameSize = 4;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', '2a', '3a', '4a', '5a', '6a', '7a', '8a', '9a', /* removed */ '11a', '12a'], 'List A');
+			expect(resultB).to.eql(['1b', '2b', '3b', '4b', '5b', 'DUPLICATE', '7b', '8b', '9b', '10b', '11b', '12b'], 'List B');
+		});
+
+		it('when frameSize=1' , () => {
+			const fn = value => value;
+			const a = ['1a', 'DUPLICATE-X', 'DUPLICATE-Y', '4a', 'DUPLICATE-Z', '6a', '7a', '8a'];
+			const b = ['DUPLICATE-X', 'DUPLICATE-Z', '3b', 'DUPLICATE-Y', '5b', '6b', '7b', '8b'];
+			const frameSize = 1;
+			const [resultA, resultB] = advanced(fn, a, b, frameSize);
+			expect(resultA).to.eql(['1a', /* removed */ 'DUPLICATE-Y', '4a', /* removed */ '6a', '7a', '8a'], 'List A');
+			expect(resultB).to.eql(['DUPLICATE-X', 'DUPLICATE-Z', '3b', /* removed */ '5b', '6b', '7b', '8b'], 'List B');
+		});
+
+	});
+});

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -3,7 +3,7 @@ const expect = chai.expect;
 chai.use(require('sinon-chai'));
 chai.use(require('chai-as-promised'));
 const proxyquire = require('proxyquire');
-const counts = require('../../server/constants');
+const { Count } = require('../../server/constants');
 const { ConceptType, Predicate } = require('../../server/lib/content');
 
 const sinon = require('sinon');
@@ -239,7 +239,7 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				expect(result.onward2.items.length).to.equal(counts.ONWARD2_COUNT);
+				expect(result.onward2.items.length).to.equal(Count.ONWARD2);
 				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104 ]);
 				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104 ]);
 				expect(result.onward.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4, 5, 6]);
@@ -268,10 +268,7 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				expect(result.onward.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104, 105, 106]);
-				expect(result.onward2.items.length).to.equal(counts.ONWARD2_COUNT);
-				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4, ]);
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4, ]);
+				expect(result.onward2.items.length).to.equal(Count.ONWARD2);
 			});
 		});
 
@@ -351,12 +348,7 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				// duplicates are not removed from the ribbon
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 'duplicate', 102, 103, 104 ], 'Duplicates should not be removed from the ribbon slot');
-				expect(result.onward.items.map(obj => obj.id)).to.eql([ 1, 2, 'duplicate', 4, 5, 6], 'Duplicates should not be removed from the onward slot');
-				// duplicates are only removed from onward 2
-				expect(result.onward2.items.length).to.equal(counts.ONWARD2_COUNT, 'onward2 slot should have the correct number of items after duplicates are removed');
-				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 102, 103, 104, 105 ], 'Duplicates should be removed from the onward2 slot');
+				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
 			});
 		});
 
@@ -382,12 +374,7 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				// duplicates are not removed from the ribbon
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 1, 2, 'duplicate', 4 ], 'Duplicates should not be removed from the ribbon slot');
-				expect(result.onward.items.map(obj => obj.id)).to.eql(['duplicate', 102, 103, 104, 105, 106], 'Duplicates should not be removed from the onward slot');
-				// duplicates are only removed from onward 2
-				expect(result.onward2.items.length).to.equal(counts.ONWARD2_COUNT, 'onward2 slot should have the correct number of items after duplicates are removed');
-				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 1, 2, 4, 5 ], 'Duplicates should be removed from the onward2 slot');
+				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
 			});
 		});
 

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -221,6 +221,8 @@ describe('related-content signal', () => {
 		it('doesn\`t return onward2 slot if there are no results', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
+			const brandItems = [];
+			const topicItems = [{ id: 1 }];
 			const content = { id: 'parent-id' };
 			const slots = {onward2: true, onward: false};
 			const flags = {onwardJourneyTests: 'variant1'};
@@ -228,12 +230,12 @@ describe('related-content signal', () => {
 			getMostRelatedConcepts.returns([topic]);
 			getBrandConcept.returns(brand);
 
-			getRelatedContent.resolves({
-				concept: topic,
-				items: [{ id: 1 }]
-			});
+			getRelatedContent.onCall(0).resolves(brandItems);
 
-			getRelatedContent.onCall(1).resolves([]);
+			getRelatedContent.onCall(1).resolves({
+				concept: topic,
+				items: topicItems,
+			});
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
@@ -303,6 +305,8 @@ describe('related-content signal', () => {
 		it('returns correct stories in slot (Variant: onwardJourneyTests=variant2)', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
+			const topicItems = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, {id: 6}];
+			const brandItems = [{ id: 101}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, {id: 106}];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
 			const flags = {onwardJourneyTests: 'variant2'};
@@ -312,17 +316,22 @@ describe('related-content signal', () => {
 
 			getRelatedContent.onCall(0).resolves({
 				concept: topic,
-				items: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, {id: 6}]
+				items: topicItems,
 			});
 
 			getRelatedContent.onCall(1).resolves({
 				concept: brand,
-				items: [{ id: 101}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, {id: 106}]
+				items: brandItems,
 			});
+
+			const id = obj => obj.id;
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
+				expect(result.onward.items.map(id)).to.eql(topicItems.map(id));
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2);
+				expect(result.onward2.items.map(id)).to.eql([ 101, 102, 103, 104, ]);
+				expect(result.ribbon.items.map(id)).to.eql([ 1, 2, 3, 4, ]);
 			});
 		});
 
@@ -383,6 +392,8 @@ describe('related-content signal', () => {
 		it('removes duplicate content when branded content in onward2 slot', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
+			const topicItems = [{ id: 'duplicate' }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
+			const brandItems = [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
 			const flags = {onwardJourneyTests: 'variant1'};
@@ -392,23 +403,30 @@ describe('related-content signal', () => {
 
 			getRelatedContent.onCall(0).resolves({
 				concept: topic,
-				items: [{ id: 1 }, { id: 2 }, { id: 'duplicate' }, { id: 4 }, { id: 5 }, { id: 6 }]
+				items: topicItems,
 			});
 
 			getRelatedContent.onCall(1).resolves({
 				concept: brand,
-				items: [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }]
+				items: brandItems,
 			});
+
+			const id = obj => obj.id;
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
+				expect(result.ribbon.items.map(id)).to.eql([ 'duplicate', 102, 103, 104 ], 'Duplicates should not be removed from the ribbon slot');
+				expect(result.onward.items.map(id)).to.eql([ 'duplicate', 2, 3, 4, 5, 6], 'Duplicates should not be removed from the onward slot');
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
+				expect(result.onward2.items.map(id)).to.eql([ 102, 103, 104, 105 ], 'Duplicates should be removed from the onward2 slot');
 			});
 		});
 
 		it('removes duplicate content when topic content in onward2 slot', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
+			const brandItems = [{ id: 1 }, { id: 2 }, { id: 'duplicate' }, { id: 4 }, { id: 5 }, { id: 6 }];
+			const topicItems = [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
 			const flags = {onwardJourneyTests: 'variant2'};
@@ -418,23 +436,37 @@ describe('related-content signal', () => {
 
 			getRelatedContent.onCall(0).resolves({
 				concept: topic,
-				items: [{ id: 1 }, { id: 2 }, { id: 'duplicate' }, { id: 4 }, { id: 5 }, { id: 6 }]
+				items: topicItems
 			});
 
 			getRelatedContent.onCall(1).resolves({
 				concept: brand,
-				items: [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }]
+				items: brandItems,
 			});
+
+			const id = obj => obj.id;
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
+				expect(result.ribbon.items.map(id)).to.eql(['duplicate', 102, 103, 104], 'Duplicates should not be removed from the ribbon slot');
+				expect(result.onward.items.map(id)).to.eql(['duplicate', 102, 103, 104, 105, 106], 'Duplicates should not be removed from the onward slot');
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
+				expect(result.onward2.items.map(id)).to.eql([ 1, 2, 4, 5 ], 'Duplicates should not be removed from the onward2 slot');
 			});
 		});
 
 		it('does not unnecessarily remove duplicate content (Variant: onwardJourneyTests=variant2)', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
+			const brandItems = [
+				{ id: 'duplicate' }, { id: 2 }, { id: 3 }, { id: 4 },
+				{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9}
+			];
+			const topicItems = [
+				{ id: 101}, { id: 102 }, { id: 103 }, { id: 104 },
+				{ id: 105 }, { id: 106 }, { id: 107 }, { id: 108 }, { id: 'duplicate' },
+				{ id: 110 }, { id: 111}, { id: 112}, { id: 113}
+			];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
 			const slots = {onward: true, onward2: true, ribbon: true};
 			const flags = {onwardJourneyTests: 'variant2'};
@@ -444,29 +476,22 @@ describe('related-content signal', () => {
 
 			getRelatedContent.onCall(0).resolves({
 				concept: topic,
-				items: [
-					{ id: 'duplicate' }, { id: 2 }, { id: 3 }, { id: 4 },
-					{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9}
-				]
+				items: topicItems,
 			});
 
 			getRelatedContent.onCall(1).resolves({
 				concept: brand,
-				items: [
-					{ id: 101}, { id: 102 }, { id: 103 }, { id: 104 },
-					{ id: 105 }, { id: 106 }, { id: 107 }, { id: 108 }, { id: 'duplicate' }
-				]
+				items: brandItems,
 			});
+
+			const id = obj => obj.id;
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				// duplicates are not removed from the ribbon
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 'duplicate', 2, 3, 4 ], 'Duplicates should not be removed from the ribbon slot');
-				expect(result.onward.items.map(obj => obj.id)).to.eql([101, 102, 103, 104, 105, 106, 107, 108], 'Duplicates should not be removed from the onward slot');
-				// duplicates are not removed from onward 2
-				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 'duplicate', 2, 3, 4 ],
-					'Nothing is removed from the onward2 slot because the index of the duplicate in the onward slot greater than the max number of items'
-				);
+				expect(result.ribbon.items.map(id)).to.eql([ 101, 102, 103, 104 ], 'Duplicates should not be removed from the ribbon slot');
+				expect(result.onward.items.map(id)).to.eql([101, 102, 103, 104, 105, 106, 107, 108, 'duplicate', 110, 111, 112], 'Duplicates should not be removed from the onward slot');
+				expect(result.onward.items.length).to.equal(12, 'Onward slot is trimmed to the correct length');
+				expect(result.onward2.items.map(id)).to.eql([ 2, 3, 4, 5 ], 'Duplicates are removed from the onward2 slot');
 			});
 		});
 
@@ -496,13 +521,15 @@ describe('related-content signal', () => {
 				]
 			});
 
+			const id = obj => obj.id;
+
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
 				// duplicates are not removed from the ribbon
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql(['duplicate', 102, 103, 104], 'Duplicates should not be removed from the ribbon slot');
-				expect(result.onward.items.map(obj => obj.id)).to.eql([1, 2, 3, 4, 5, 6, 7, 8], 'Duplicates should not be removed from the onward slot');
+				expect(result.ribbon.items.map(id)).to.eql(['duplicate', 102, 103, 104], 'Duplicates should not be removed from the ribbon slot');
+				expect(result.onward.items.map(id)).to.eql([1, 2, 3, 4, 5, 6, 7, 8], 'Duplicates should not be removed from the onward slot');
 				// duplicates are not removed from onward 2
-				expect(result.onward2.items.map(obj => obj.id)).to.eql(['duplicate', 102, 103, 104],
+				expect(result.onward2.items.map(id)).to.eql(['duplicate', 102, 103, 104],
 					'Nothing is removed from the onward2 slot because the index of the duplicate in the onward slot greater than the max number of items'
 				);
 			});


### PR DESCRIPTION
Variant2 will now act a kind of control to Variant 1.

The actual control behaviour has no changes to way content selected (ie the topic the article is about) or the amount of stories displayed. 

However, Variant 1 changes the way content is selected _and_ in _some_ cases displays _more_ recommendations to the reader.

Previously Variant 2 was a mild difference to Variant1 (described above).

But with this change, Variant 2 now selects content in almost the same way as the control (ie only by topic) _and_ displays more stories *at the same rate* as Variant1. Doing it at the same rate is important to get accurate results and helps us know if simply showing more stories caused a differences.

There were some important aspects to the previous implementation of Variant 2 that we've tried to keep by rolling them into Variant 1. So now were' detecting whether slots will be shown to the user. The ribbon, for example, is not displayed when the article has a topper or is in a Content Package. In this case we want to change the priority/order of how the content is displayed.

PR also includes some light refactoring for readability and a change to the way deduping works (because the change would otherwise break deduping)