### PR TITLE
Remove mention of Fastly service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 ## Architecture
 
 - heroku in 2 regions
-- fronted by fastly instance, lure-api.ft.com, generally only used for non-personalised, server <-> server communication
-- in addition, served directly on www.ft.com/lure for personalised responses
+- served directly on www.ft.com/lure for personalised responses
 
 ## Contract
 


### PR DESCRIPTION
I can't find any record of a Fastly service or the lure-api.ft.com domain existing.