### PR TITLE
Fix output when flag is not an MVT test

### DIFF
--- a/server/middleware/respond.js
+++ b/server/middleware/respond.js
@@ -51,6 +51,7 @@ module.exports = (_, res) => {
 	response._metadata = {
 		flagState: {
 			onwardJourneyTests: flags.onwardJourneyTests || 'control',
+			hideTopRibbon: flags.hideTopRibbon,
 		},
 		numSlots,
 		totalItems,

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -17,6 +17,10 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		slots.ribbon = false;
 	}
 
+	if (flags.hideTopRibbon) {
+		slots.ribbon = false;
+	}
+
 	if (!canShowBottomSlotOnPage(content)) {
 		slots.onward = false;
 		slots.onward2 = false;

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -68,6 +68,10 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 			onward2 = brand;
 			contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
 			contentSelection.onward2 = ContentSelection.BRAND;
+		} else {
+			ribbon = topic;
+			onward = topic;
+			contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
 		}
 	}
 


### PR DESCRIPTION
`a181d7b` fixes the case when the flag is on, but is not an Ammit flag. It will serve a default selection of content.

`4e40821` also introduces a new flag called `hideTopRibbon`. While this has also been added to next-article, having it hear allows us to maintain our analytics and metrics. ie we know how often each slots is sent, taking into account the various rules about when to show them, which is useful in determining how the rules work in production.

Adding the new flags to next-article isn't really needed, this implementation should be enough. Flags are passed to the Lure API direct from Ammit as the calls from the browser go via Preflight.