### PR TITLE
Remove Ribbon slot

### DIFF
--- a/server/constants.js
+++ b/server/constants.js
@@ -1,7 +1,6 @@
 const BOTTOM_ROW_SIZE = 4;
 
 const Count = {
-	RIBBON: 4,
 	ONWARD:  BOTTOM_ROW_SIZE * 2,
 	ONWARD2: BOTTOM_ROW_SIZE * 1,
 };

--- a/server/lib/can-show-on-page.js
+++ b/server/lib/can-show-on-page.js
@@ -1,15 +1,3 @@
-function canShowRibbonOnPage (content) {
-	if (content.topper && content.topper.layout) {
-		return false;
-	}
-
-	if (Array.isArray(content.containedIn) && content.containedIn.length) {
-		return false;
-	}
-
-	return true;
-}
-
 function canShowBottomSlotOnPage (content) {
 	if (Array.isArray(content.containedIn) && content.containedIn.length) {
 		return false;
@@ -20,5 +8,4 @@ function canShowBottomSlotOnPage (content) {
 
 module.exports = {
 	canShowBottomSlotOnPage,
-	canShowRibbonOnPage,
 };

--- a/server/lib/get-brand-concept.js
+++ b/server/lib/get-brand-concept.js
@@ -27,7 +27,7 @@ module.exports.priorityList = new Map([
 	// Weighted Down:
 	// The Special Reports brand has many sub-brands. When one of the sub-brands
 	// is in use we'd favour it over the broader/generic Special Reports brand
-	[conceptIds.brand.specialReport, -1],
+	[conceptIds.brand.specialReport, Priority.NEGATIVE],
 ]);
 
 // A list of non-brand concepts (mainly genres) that a user might

--- a/server/middleware/handle-options.js
+++ b/server/middleware/handle-options.js
@@ -5,7 +5,7 @@ module.exports = (req, res, next) => {
 		.reduce((map, key) => {
 			map[key] = true;
 			return map;
-		}, {}) : {'ribbon': true, 'onward': true, 'onward2': true};
+		}, {}) : {onward: true, onward2: true};
 
 	res.locals.userId = req.query.userId;
 	res.locals.secureSessionToken = req.get('FT-Session-s-Token') || req.cookies.FTSession_s;

--- a/server/middleware/respond.js
+++ b/server/middleware/respond.js
@@ -31,10 +31,6 @@ module.exports = (_, res) => {
 	const { recommendations, flags = {} } = res.locals;
 	const response = {};
 
-	if (recommendations.ribbon) {
-		response.ribbon = finishModel(recommendations.ribbon, 'Latest');
-	}
-
 	if (recommendations.onward) {
 		response.onward = finishModel(recommendations.onward, 'Latest');
 	}
@@ -51,7 +47,6 @@ module.exports = (_, res) => {
 	response._metadata = {
 		flagState: {
 			onwardJourneyTests: flags.onwardJourneyTests || 'control',
-			hideTopRibbon: Boolean(flags.hideTopRibbon),
 		},
 		numSlots,
 		totalItems,
@@ -70,7 +65,6 @@ module.exports = (_, res) => {
 	res.json(response);
 
 	metrics.count(`flags.onwardJourneyTests.${flags.onwardJourneyTests || 'control'}`);
-	metrics.count(`slots.ribbon.${Boolean(response.ribbon)}`);
 	metrics.count(`slots.onward.${Boolean(response.onward)}`);
 	metrics.count(`slots.onward2.${Boolean(response.onward2)}`);
 };

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -1,7 +1,7 @@
 const getMostRelatedConcepts = require('../lib/get-most-related-concepts');
 const getBrandConcept = require('../lib/get-brand-concept');
 const getRelatedContent = require('../lib/get-related-content');
-const {Count, ContentSelection, TestVariant} = require('../constants');
+const { Count, ContentSelection, TestVariant } = require('../constants');
 const { canShowBottomSlotOnPage, canShowRibbonOnPage } = require('../lib/can-show-on-page');
 const dedupe = require('../lib/dedupe');
 

--- a/server/signals/related-content.js
+++ b/server/signals/related-content.js
@@ -2,24 +2,16 @@ const getMostRelatedConcepts = require('../lib/get-most-related-concepts');
 const getBrandConcept = require('../lib/get-brand-concept');
 const getRelatedContent = require('../lib/get-related-content');
 const { Count, ContentSelection, TestVariant } = require('../constants');
-const { canShowBottomSlotOnPage, canShowRibbonOnPage } = require('../lib/can-show-on-page');
+const { canShowBottomSlotOnPage } = require('../lib/can-show-on-page');
 const dedupe = require('../lib/dedupe');
 
 async function relatedContent (content, {locals: {flags = {}, slots}}) {
-	const count = Math.max(Count.RIBBON, Count.ONWARD, Count.ONWARD2);
+	const count = Math.max(Count.ONWARD, Count.ONWARD2);
 	let topic;
 	let brand;
 
 	const relatedConcepts = getMostRelatedConcepts(content) || [];
 	const topicConcept = relatedConcepts[0];
-
-	if (!canShowRibbonOnPage(content)) {
-		slots.ribbon = false;
-	}
-
-	if (flags.hideTopRibbon) {
-		slots.ribbon = false;
-	}
 
 	if (!canShowBottomSlotOnPage(content)) {
 		slots.onward = false;
@@ -39,43 +31,30 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		}
 	}
 
-	let ribbon;
 	let onward;
 	let onward2;
 	let contentSelection = {};
 
 	if (topic && !brand) {
-		ribbon = topic;
 		onward = topic;
-		contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
+		contentSelection.onward = ContentSelection.TOPIC;
 	} else if (!topic && brand) {
-		ribbon = brand;
 		onward = brand;
-		contentSelection.ribbon = contentSelection.onward = ContentSelection.BRAND;
+		contentSelection.onward = ContentSelection.BRAND;
 	} else if (topic && brand) {
 		if (flags.onwardJourneyTests === TestVariant.Variant1) {
-			if (slots.ribbon) {
-				ribbon = brand;
-				onward = topic;
-				onward2 = brand;
-				contentSelection.ribbon = contentSelection.onward2 = ContentSelection.BRAND;
-				contentSelection.onward = ContentSelection.TOPIC;
-			} else {
-				onward = brand;
-				onward2 = topic;
-				contentSelection.onward = ContentSelection.BRAND;
-				contentSelection.onward2 = ContentSelection.TOPIC;
-			}
+			onward = brand;
+			onward2 = topic;
+			contentSelection.onward = ContentSelection.BRAND;
+			contentSelection.onward2 = ContentSelection.TOPIC;
 		} else if (flags.onwardJourneyTests === TestVariant.Variant2) {
-			ribbon = topic;
 			onward = topic;
 			onward2 = brand;
-			contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
+			contentSelection.onward = ContentSelection.TOPIC;
 			contentSelection.onward2 = ContentSelection.BRAND;
 		} else {
-			ribbon = topic;
 			onward = topic;
-			contentSelection.ribbon = contentSelection.onward = ContentSelection.TOPIC;
+			contentSelection.onward = ContentSelection.TOPIC;
 		}
 	}
 
@@ -101,7 +80,6 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 	}
 
 	await Promise.all([
-		slot('ribbon', ribbon),
 		slot('onward', onward),
 		slot('onward2', onward2),
 	]);
@@ -113,22 +91,12 @@ async function relatedContent (content, {locals: {flags = {}, slots}}) {
 		delete response.onward2;
 	}
 
-	if (!canShowRibbonOnPage(content)) {
-		delete response.ribbon;
-	}
-
 	if (!canShowBottomSlotOnPage(content)) {
 		delete response.onward;
 		delete response.onward2;
 	}
 
 	// Dedupe & trim each list...
-
-	if (response.ribbon) {
-		// Ribbon is not considered when deduping
-		response.ribbon.items = response.ribbon.items.slice(0, Count.RIBBON);
-	}
-
 	if (response.onward && response.onward2) {
 		if (flags.onwardJourneyTests === TestVariant.Variant2) {
 			// Dedupe strategy:

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -42,7 +42,7 @@ describe('lure e2e', () => {
 
 	context('success', () => {
 
-		before(() => rawData = {ribbon: {}});
+		before(() => rawData = {onward:{}});
 
 		it('sets appropriate cache headers', async () => {
 			return request(app)
@@ -53,14 +53,6 @@ describe('lure e2e', () => {
 
 		it('converts concepts to headings and links', () => {
 			rawData = {
-				ribbon: {
-					items: getItems(5),
-					concept: {
-						prefLabel: 'Stuff',
-						preposition: 'examplePrepos',
-						relativeUrl: '/exampleLink'
-					}
-				},
 				onward2: {
 					items: getItems(5),
 					concept: {
@@ -74,8 +66,6 @@ describe('lure e2e', () => {
 			return request(app)
 				.get('/lure/v2/content/uuid')
 				.then(({body}) => {
-					expect(body.ribbon.title).to.equal('Latest examplePrepos Stuff');
-					expect(body.ribbon.titleHref).to.equal('/exampleLink');
 					expect(body.onward2.title).to.equal('More examplePrepos Stuff');
 					expect(body.onward2.titleHref).to.equal('/exampleLink');
 				});
@@ -84,9 +74,6 @@ describe('lure e2e', () => {
 		context('when fetching v2 style data', () => {
 			before(() => {
 				rawData = {
-					ribbon: {
-						items: getItems(4)
-					},
 					onward: {
 						items: getItems(7),
 					}
@@ -97,7 +84,6 @@ describe('lure e2e', () => {
 				return request(app)
 					.get('/lure/v2/content/uuid')
 					.then(({body}) => {
-						expect(body.ribbon.items.length).to.equal(4);
 						expect(Array.isArray(body.onward)).to.be.false;
 						expect(body.onward.items.length).to.equal(7);
 						expect(uniqueIds('items', [body.onward])).to.be.true;

--- a/test/lib/can-show-on-page.spec.js
+++ b/test/lib/can-show-on-page.spec.js
@@ -1,39 +1,7 @@
 const { expect } = require('chai');
-const { canShowRibbonOnPage, canShowBottomSlotOnPage } = require('../../server/lib/can-show-on-page');
+const { canShowBottomSlotOnPage } = require('../../server/lib/can-show-on-page');
 
 describe('lib/can-show-in-slot.js', () => {
-
-	describe('canShowRibbonOnPage', () => {
-		it('happy path', () => {
-			const content = { id: 'content-id' };
-			const result = canShowRibbonOnPage(content);
-			expect(result).to.eql(true);
-		});
-
-		it('Content has an empty topper', () => {
-			const content = { topper: {} };
-			const result = canShowRibbonOnPage(content);
-			expect(result).to.eql(true);
-		});
-
-		it('Content has a custom Editorial topper', () => {
-			const content = { topper: { layout: 'full-bleed-offset' } };
-			const result = canShowRibbonOnPage(content);
-			expect(result).to.eql(false);
-		});
-
-		it('Content containedIn in NO ContentPackages', () => {
-			const content = { containedIn: [] };
-			const result = canShowRibbonOnPage(content);
-			expect(result).to.eql(true);
-		});
-
-		it('Content containedIn in One ContentPackages', () => {
-			const content = { containedIn: [ {id:'content-package'} ] };
-			const result = canShowRibbonOnPage(content);
-			expect(result).to.eql(false);
-		});
-	});
 
 	describe('canShowBottomSlotOnPage', () => {
 		it('happy path', () => {

--- a/test/middleware/get-recommendations.spec.js
+++ b/test/middleware/get-recommendations.spec.js
@@ -15,7 +15,7 @@ const getMockArgs = (sandbox, headers = {}) => {
 	}, {
 		locals: {
 			flags: {},
-			slots: { ribbon: true },
+			slots: { onward: true },
 			content: {
 				id: 'content-id'
 			}

--- a/test/middleware/respond.spec.js
+++ b/test/middleware/respond.spec.js
@@ -74,7 +74,7 @@ describe('respond middleware', () => {
 		const res = {
 			locals: {
 				recommendations: {
-					ribbon: {
+					onward: {
 						title: 'title',
 						titleHref: '/stream/id',
 						items: [{}, {}, {}],
@@ -96,12 +96,11 @@ describe('respond middleware', () => {
 			_metadata: {
 				flagState: {
 					onwardJourneyTests: 'test-flag-value',
-					hideTopRibbon: false,
 				},
 				numSlots: 1,
 				totalItems: 3,
 				contentSelection: {
-					ribbon: 'content-selection-value'
+					onward: 'content-selection-value'
 				},
 			}
 		};

--- a/test/signals/related-content.spec.js
+++ b/test/signals/related-content.spec.js
@@ -104,94 +104,12 @@ describe('related-content signal', () => {
 
 	});
 
-	context('ribbon slot', () => {
-
-		it('return empty object if no concepts available', () => {
-			const content = {id: 'parent-id'};
-			const slots = {ribbon: true};
-			getMostRelatedConcepts.returns(undefined);
-			const promise = subject(content, {locals: {slots}});
-			return expect(promise).to.eventually.eql({});
-		});
-
-
-		it('show correct number of stories', () => {
-			const concept = annotation('concept-id', ConceptType.Topic, Predicate.about);
-			const content = { id: 'parent-id', annotations: [concept] };
-			const slots = {ribbon: true};
-			getRelatedContent.resolves({
-				concept,
-				items: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
-			});
-			const promise = subject(content, {locals: {slots}});
-			return promise.then(result => {
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4 ]);
-			});
-		});
-
-		it('use brand stories when flag onwardJourneyTests=variant1 ', () => {
-			const concept = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
-			const content = { id: 'parent-id', annotations: [concept] };
-			const slots = {ribbon: true};
-			const flags = {onwardJourneyTests: 'variant1'};
-
-			getRelatedContent.resolves({
-				concept,
-				items: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
-			});
-
-			const promise = subject(content, {locals: {slots, flags}});
-			return promise.then(result => {
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4 ]);
-			});
-		});
-
-		it('don\'t show if no teasers', () => {
-			const concept = annotation(0, ConceptType.Topic, Predicate.about);
-			const content = { id: 'parent-id', annotations: [concept] };
-			const slots = {ribbon: true};
-			getMostRelatedConcepts.returns([concept]);
-			getRelatedContent.resolves({
-				concept,
-				items: []
-			});
-			const promise = subject(content, {locals: {slots}});
-			return expect(promise).to.eventually.eql({});
-		});
-
-		it('don\'t show if there is a topper on the content', () => {
-			const concept = annotation(0, ConceptType.Topic, Predicate.about);
-			const content = { id: 'parent-id', annotations: [concept], topper: { layout: 'full-bleed-offset' } };
-			const slots = {ribbon: true};
-			getMostRelatedConcepts.returns([concept]);
-			getRelatedContent.resolves({
-				concept,
-				items: [{id: 1}, {id: 2}]
-			});
-			const promise = subject(content, {locals: {slots}});
-			return expect(promise).to.eventually.eql({});
-		});
-
-		it('don\'t show if the article is contained in Content Package', () => {
-			const concept = annotation(0, ConceptType.Topic, Predicate.about);
-			const content = { id: 'content-id', annotations: [concept], containedIn: [{id: 'package-id'}] };
-			const slots = {ribbon: true};
-			getMostRelatedConcepts.returns([concept]);
-			getRelatedContent.resolves({
-				concept,
-				items: [{id: 1}, {id: 2}]
-			});
-			const promise = subject(content, {locals: {slots}});
-			return expect(promise).to.eventually.eql({});
-		});
-	});
-
 	context('onward2 slot', () => {
 		it('doesn\`t return onward2 slot if onwardJourneyTests flag is off', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id' };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -214,7 +132,6 @@ describe('related-content signal', () => {
 				expect(getRelatedContent).to.have.been.calledOnce;
 				expect(result).to.not.include.keys('onward2');
 				expect(result).to.include.keys('onward');
-				expect(result).to.include.keys('ribbon');
 			});
 		});
 
@@ -241,7 +158,6 @@ describe('related-content signal', () => {
 			return promise.then(result => {
 				expect(result).to.not.include.keys('onward2');
 				expect(result).to.not.include.keys('onward');
-				expect(result).to.not.include.keys('ribbon');
 			});
 		});
 
@@ -249,7 +165,7 @@ describe('related-content signal', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -268,9 +184,8 @@ describe('related-content signal', () => {
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2);
-				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104 ]);
-				expect(result.ribbon.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104 ]);
-				expect(result.onward.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4, 5, 6]);
+				expect(result.onward.items.map(obj => obj.id)).to.eql([ 101, 102, 103, 104, 105, 106 ]);
+				expect(result.onward2.items.map(obj => obj.id)).to.eql([ 1, 2, 3, 4]);
 			});
 		});
 
@@ -278,7 +193,7 @@ describe('related-content signal', () => {
 			const brand = annotation(0, ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation(1, ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic], containedIn: [{id: 'package-id'}] };
-			const slots = {onward: true, onward2: true, ribbon: false};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -298,7 +213,6 @@ describe('related-content signal', () => {
 			return promise.then(result => {
 				expect(result).to.not.include.keys('onward');
 				expect(result).to.not.include.keys('onward2');
-				expect(result).to.not.include.keys('ribbon');
 			});
 		});
 
@@ -308,7 +222,7 @@ describe('related-content signal', () => {
 			const topicItems = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, {id: 6}];
 			const brandItems = [{ id: 101}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, {id: 106}];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -331,7 +245,6 @@ describe('related-content signal', () => {
 				expect(result.onward.items.map(id)).to.eql(topicItems.map(id));
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2);
 				expect(result.onward2.items.map(id)).to.eql([ 101, 102, 103, 104, ]);
-				expect(result.ribbon.items.map(id)).to.eql([ 1, 2, 3, 4, ]);
 			});
 		});
 
@@ -389,13 +302,13 @@ describe('related-content signal', () => {
 			});
 		});
 
-		it('removes duplicate content when branded content in onward2 slot', () => {
+		it('removes duplicate content when topic content in onward2 slot', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
-			const topicItems = [{ id: 'duplicate' }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
-			const brandItems = [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }];
+			const brandItems = [{ id: 'duplicate' }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
+			const topicItems = [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -415,20 +328,19 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				expect(result.ribbon.items.map(id)).to.eql([ 'duplicate', 102, 103, 104 ], 'Duplicates should not be removed from the ribbon slot');
 				expect(result.onward.items.map(id)).to.eql([ 'duplicate', 2, 3, 4, 5, 6], 'Duplicates should not be removed from the onward slot');
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
 				expect(result.onward2.items.map(id)).to.eql([ 102, 103, 104, 105 ], 'Duplicates should be removed from the onward2 slot');
 			});
 		});
 
-		it('removes duplicate content when topic content in onward2 slot', () => {
+		it('removes duplicate content when brand content in onward2 slot', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const brandItems = [{ id: 1 }, { id: 2 }, { id: 'duplicate' }, { id: 4 }, { id: 5 }, { id: 6 }];
 			const topicItems = [{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 }, { id: 105 }, { id: 106 }];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -448,7 +360,6 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				expect(result.ribbon.items.map(id)).to.eql(['duplicate', 102, 103, 104], 'Duplicates should not be removed from the ribbon slot');
 				expect(result.onward.items.map(id)).to.eql(['duplicate', 102, 103, 104, 105, 106], 'Duplicates should not be removed from the onward slot');
 				expect(result.onward2.items.length).to.equal(Count.ONWARD2, 'onward2 slot should have the correct number of items after duplicates are removed');
 				expect(result.onward2.items.map(id)).to.eql([ 1, 2, 4, 5 ], 'Duplicates should not be removed from the onward2 slot');
@@ -468,7 +379,7 @@ describe('related-content signal', () => {
 				{ id: 110 }, { id: 111}, { id: 112}, { id: 113}
 			];
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = {onward: true, onward2: true};
 			const flags = {onwardJourneyTests: 'variant2'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -488,7 +399,6 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				expect(result.ribbon.items.map(id)).to.eql([ 101, 102, 103, 104 ], 'Duplicates should not be removed from the ribbon slot');
 				expect(result.onward.items.map(id)).to.eql([101, 102, 103, 104, 105, 106, 107, 108, 'duplicate', 110, 111, 112], 'Duplicates should not be removed from the onward slot');
 				expect(result.onward.items.length).to.equal(12, 'Onward slot is trimmed to the correct length');
 				expect(result.onward2.items.map(id)).to.eql([ 2, 3, 4, 5 ], 'Duplicates are removed from the onward2 slot');
@@ -499,7 +409,7 @@ describe('related-content signal', () => {
 			const brand = annotation('brand-id', ConceptType.Brand, Predicate.isClassifiedBy);
 			const topic = annotation('topic-id', ConceptType.Topic, Predicate.about);
 			const content = { id: 'parent-id', annotations: [brand, topic] };
-			const slots = {onward: true, onward2: true, ribbon: true};
+			const slots = { onward: true, onward2: true };
 			const flags = {onwardJourneyTests: 'variant1'};
 
 			getMostRelatedConcepts.returns([topic]);
@@ -508,16 +418,16 @@ describe('related-content signal', () => {
 			getRelatedContent.onCall(0).resolves({
 				concept: topic,
 				items: [
-					{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 },
-					{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 'duplicate'}
+					{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 },
+					{ id: 105 }, { id: 106 }, { id: 107 }, { id: 108 }, { id: 109 }
 				]
 			});
 
 			getRelatedContent.onCall(1).resolves({
 				concept: brand,
 				items: [
-					{ id: 'duplicate'}, { id: 102 }, { id: 103 }, { id: 104 },
-					{ id: 105 }, { id: 106 }, { id: 107 }, { id: 108 }, { id: 109 }
+					{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 },
+					{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 'duplicate'}
 				]
 			});
 
@@ -525,8 +435,6 @@ describe('related-content signal', () => {
 
 			const promise = subject(content, {locals: {slots, flags}});
 			return promise.then(result => {
-				// duplicates are not removed from the ribbon
-				expect(result.ribbon.items.map(id)).to.eql(['duplicate', 102, 103, 104], 'Duplicates should not be removed from the ribbon slot');
 				expect(result.onward.items.map(id)).to.eql([1, 2, 3, 4, 5, 6, 7, 8], 'Duplicates should not be removed from the onward slot');
 				// duplicates are not removed from onward 2
 				expect(result.onward2.items.map(id)).to.eql(['duplicate', 102, 103, 104],


### PR DESCRIPTION
The component has already been removed from the front
end (see [`next-article` #4575](Financial-Times/next-article#4575)).

The ribbon was a special case and not like the other two slots.
For example, duplicates were not removed from the Ribbon.
We may have to bring back some of this logic in the future
if we invent new slots.

For now, removing this code allows us to refactor the app so
it's cleaner, easier to test and extend.