### PR TITLE
Replace Sentry with Reliability Kit Crash Handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,10 @@
     "": {
       "name": "ft-next-lure-api",
       "dependencies": {
+        "@dotcom-reliability-kit/crash-handler": "^2.1.1",
         "@financial-times/n-concept-ids": "1.18.0",
         "@financial-times/n-es-client": "4.2.1",
-        "@financial-times/n-express": "26.3.14",
+        "@financial-times/n-express": "^27.5.0",
         "@financial-times/n-logger": "10.3.1",
         "cookie-parser": "^1.4.3",
         "express-async-errors": "^3.1.1",
@@ -396,13 +397,67 @@
         "npm": "7.x || 8.x"
       }
     },
-    "node_modules/@dotcom-reliability-kit/errors": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.2.7.tgz",
-      "integrity": "sha512-P53G0vCEP0AHwavUIZR3C1nCSlmTHLCgrrr8o4sjTlBQpbmiceRzWLTCWYvKluQxzCXTpSiiCenrgjK4ZdoAbQ==",
+    "node_modules/@dotcom-reliability-kit/crash-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-2.1.1.tgz",
+      "integrity": "sha512-IbmKCK6LPLYMN/7873xA9hkGjcZJnMk2jOANQ4t8BhKejKWkOiZE2wpOovtcUQcD7hFMyMhtpCEMxoe31MSTXg==",
+      "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^2.1.1"
+      },
       "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+      "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-2.1.1.tgz",
+      "integrity": "sha512-ZJn+y8qQs5Bai2SBsopHT9E87aMhY31jCRYeQbkSMd/JRjFitjOjRyMAXDG1zVBtmwauX+wEcRKXgqoKgWmgdw==",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.2.0",
+        "@financial-times/n-logger": "^10.3.1"
+      },
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/crash-handler/node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/errors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.1.1.tgz",
+      "integrity": "sha512-oumFLYMo4zsVP7/+CBgJ/z0oOthZAlQxTI3Yn45MjkAtMoq7zasqXGPLVTDZoXgDtkdlUu/OJyTs6G4I1WVKPA==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/log-error": {
@@ -489,31 +544,48 @@
       }
     },
     "node_modules/@financial-times/n-express": {
-      "version": "26.3.14",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-26.3.14.tgz",
-      "integrity": "sha512-XSsBJYnznfF5/hkhGAVI8MaYwWTPCJEccZL/XLDM79tB40wbRPSmAREocfLKKcREIF42fOJ9ECR40I/AFnUb2g==",
-      "hasInstallScript": true,
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
+      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
       "dependencies": {
-        "@dotcom-reliability-kit/errors": "^1.2.7",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.6",
+        "@dotcom-reliability-kit/errors": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.0.0",
+        "@financial-times/n-flags-client": "^13.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.2",
-        "next-metrics": "^7.6.3",
+        "n-health": "^10.0.0",
+        "next-metrics": "^9.2.0",
         "semver": "^7.3.7"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+      "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-express/node_modules/lru-cache": {
@@ -525,6 +597,42 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/n-health": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
+      "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
+      "dependencies": {
+        "@financial-times/n-logger": "^10.2.0",
+        "aws-sdk": "^2.6.10",
+        "fetchres": "^1.5.1",
+        "moment": "^2.29.4",
+        "ms": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@financial-times/n-express/node_modules/semver": {
@@ -539,6 +647,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@financial-times/n-express/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@financial-times/n-express/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@financial-times/n-express/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@financial-times/n-express/node_modules/yallist": {
@@ -582,18 +709,17 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
-      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
-      "hasInstallScript": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
+      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^6.0.1",
+        "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@financial-times/n-gage": {
@@ -6847,9 +6973,9 @@
       }
     },
     "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6868,17 +6994,17 @@
     "node_modules/isomorphic-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/isomorphic-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/isomorphic-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -8058,17 +8184,16 @@
       "dev": true
     },
     "node_modules/n-eager-fetch": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.2.tgz",
-      "integrity": "sha512-iJ0M9kkcwGbM/4M+SqXq/7OR+RG269p82mI9bewgpL0sYCPAhC3bzlXtCGRsfj4Wd8Xx1PN2yCnYXm3lUYpDcQ==",
-      "hasInstallScript": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+      "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
         "npm-prepublish": "^1.2.2"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/n-health": {
@@ -8231,18 +8356,17 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.3.tgz",
-      "integrity": "sha512-EJk+OmOIIi7plxYU3alw6dCwxMBi1nPDHN9+Si5Qw25vurqtGRc5cBVEXgeVpktvSQXnK7K+8IG8NPSIcUOKbQ==",
-      "hasInstallScript": true,
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
+      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/nice-try": {
@@ -13276,10 +13400,46 @@
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
       "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA=="
     },
+    "@dotcom-reliability-kit/crash-handler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/crash-handler/-/crash-handler-2.1.1.tgz",
+      "integrity": "sha512-IbmKCK6LPLYMN/7873xA9hkGjcZJnMk2jOANQ4t8BhKejKWkOiZE2wpOovtcUQcD7hFMyMhtpCEMxoe31MSTXg==",
+      "requires": {
+        "@dotcom-reliability-kit/log-error": "^2.1.1"
+      },
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+          "integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
+        },
+        "@dotcom-reliability-kit/log-error": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-2.1.1.tgz",
+          "integrity": "sha512-ZJn+y8qQs5Bai2SBsopHT9E87aMhY31jCRYeQbkSMd/JRjFitjOjRyMAXDG1zVBtmwauX+wEcRKXgqoKgWmgdw==",
+          "requires": {
+            "@dotcom-reliability-kit/app-info": "^2.1.0",
+            "@dotcom-reliability-kit/serialize-error": "^2.1.0",
+            "@dotcom-reliability-kit/serialize-request": "^2.2.0",
+            "@financial-times/n-logger": "^10.3.1"
+          }
+        },
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+        },
+        "@dotcom-reliability-kit/serialize-request": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+          "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
+        }
+      }
+    },
     "@dotcom-reliability-kit/errors": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.2.7.tgz",
-      "integrity": "sha512-P53G0vCEP0AHwavUIZR3C1nCSlmTHLCgrrr8o4sjTlBQpbmiceRzWLTCWYvKluQxzCXTpSiiCenrgjK4ZdoAbQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.1.1.tgz",
+      "integrity": "sha512-oumFLYMo4zsVP7/+CBgJ/z0oOthZAlQxTI3Yn45MjkAtMoq7zasqXGPLVTDZoXgDtkdlUu/OJyTs6G4I1WVKPA=="
     },
     "@dotcom-reliability-kit/log-error": {
       "version": "1.5.0",
@@ -13345,25 +13505,35 @@
       }
     },
     "@financial-times/n-express": {
-      "version": "26.3.14",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-26.3.14.tgz",
-      "integrity": "sha512-XSsBJYnznfF5/hkhGAVI8MaYwWTPCJEccZL/XLDM79tB40wbRPSmAREocfLKKcREIF42fOJ9ECR40I/AFnUb2g==",
+      "version": "27.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-27.5.0.tgz",
+      "integrity": "sha512-5B+6mERRMvF/mUs5d2XDHKYXLke1BaKk0q00rJQ9yqY7Ti998qA0DYCKT60MVDhEeyqQzsVEcniadDnl1LcaTg==",
       "requires": {
-        "@dotcom-reliability-kit/errors": "^1.2.7",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.6",
+        "@dotcom-reliability-kit/errors": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^2.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^2.0.0",
+        "@financial-times/n-flags-client": "^13.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.2",
-        "next-metrics": "^7.6.3",
+        "n-health": "^10.0.0",
+        "next-metrics": "^9.2.0",
         "semver": "^7.3.7"
       },
       "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+          "integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
+        },
+        "@dotcom-reliability-kit/serialize-request": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-2.2.0.tgz",
+          "integrity": "sha512-jM8GWWFzBFAXVkv1PPssAFC7mZLoEac9LV5HIINKmhxxe+av3eXJH53MwNQUARMqrIA3Hm7D7khT4L5gnuGcDg=="
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -13372,12 +13542,52 @@
             "yallist": "^4.0.0"
           }
         },
+        "n-health": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/n-health/-/n-health-10.1.1.tgz",
+          "integrity": "sha512-cUQVhRjYtglmvEEjErGUJeiKrVYfi3bKtb0D8v7v0rxP0OgFFR1DE22d6l+FpwkOhhhBMrO7+BZsdwFcVfl7cQ==",
+          "requires": {
+            "@financial-times/n-logger": "^10.2.0",
+            "aws-sdk": "^2.6.10",
+            "fetchres": "^1.5.1",
+            "moment": "^2.29.4",
+            "ms": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
           }
         },
         "yallist": {
@@ -13422,12 +13632,12 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
-      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-13.1.1.tgz",
+      "integrity": "sha512-OiTm75rweyaNtggkUTzUQk4tS6+vI6HKwxLtghee7zAZLlL/BB0WP3JWeIpw5DRVSBzpSx1L8fhsHyydwLWfLg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^6.0.1",
+        "n-eager-fetch": "^7.0.0",
         "vary": "^1.1.2"
       }
     },
@@ -18284,9 +18494,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -18294,17 +18504,17 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -19234,9 +19444,9 @@
       "dev": true
     },
     "n-eager-fetch": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.2.tgz",
-      "integrity": "sha512-iJ0M9kkcwGbM/4M+SqXq/7OR+RG269p82mI9bewgpL0sYCPAhC3bzlXtCGRsfj4Wd8Xx1PN2yCnYXm3lUYpDcQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-7.1.0.tgz",
+      "integrity": "sha512-tPlZDKf1Tzir0czXvu63wuZb5RDIP+Lpqq56dfVu06qJqerAedUp2LspFbKQfxBKZdwpnKf5R9NLLZhEfR5tlQ==",
       "requires": {
         "isomorphic-fetch": "^3.0.0",
         "npm-prepublish": "^1.2.2"
@@ -19375,9 +19585,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.3.tgz",
-      "integrity": "sha512-EJk+OmOIIi7plxYU3alw6dCwxMBi1nPDHN9+Si5Qw25vurqtGRc5cBVEXgeVpktvSQXnK7K+8IG8NPSIcUOKbQ==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.4.0.tgz",
+      "integrity": "sha512-02pQOyfyz7eHeWj+AjupBER6rZAJ06n3yd9SOY6eQYkLi1bPbjhmCXUoOnyBrM5gLM9V5ogw4n6j/OlBTVaGvg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "homepage": "https://github.com/Financial-Times/next-lure-api#readme",
   "dependencies": {
+    "@dotcom-reliability-kit/crash-handler": "^2.1.1",
     "@financial-times/n-concept-ids": "1.18.0",
     "@financial-times/n-es-client": "4.2.1",
-    "@financial-times/n-express": "26.3.14",
+    "@financial-times/n-express": "^27.5.0",
     "@financial-times/n-logger": "10.3.1",
     "cookie-parser": "^1.4.3",
     "express-async-errors": "^3.1.1",

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,9 @@ require('express-async-errors');
 const healthchecks = require('./healthchecks');
 const errorHandler = require('./middleware/error-handler');
 const logger = require('@financial-times/n-logger').default;
+const registerCrashHandler = require('@dotcom-reliability-kit/crash-handler');
+
+registerCrashHandler();
 
 const app = express({
 	systemCode: 'next-lure-api',


### PR DESCRIPTION
Part of [CPREL-649](https://financialtimes.atlassian.net/browse/CPREL-649). The n-express update in this PR is safe as it drops Node.js 14 support and disables Sentry by default.


[CPREL-649]: https://financialtimes.atlassian.net/browse/CPREL-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ