### PR TITLE
[CON-2723] - Migrate to Node v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
     &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:16.14-browsers
+      - image: cimg/node:18.17-browsers
 
   workspace_root: &workspace_root ~/project
 
@@ -70,11 +70,9 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch unpin-heroku
             .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "7"
       - run:
           name: Install project dependencies
           command: make install
@@ -121,7 +119,7 @@ jobs:
             HEROKU_LOGIN: next.developers@ft.com
       - run:
           name: Create and test Heroku review app
-          command: make test-review-app
+          command: NODE_OPTIONS="--no-experimental-fetch" make test-review-app
 
   deploy:
     <<: *container_config_node
@@ -139,7 +137,7 @@ jobs:
           --project-name=Financial-Times/next-lure-api
       - run:
           name: Deploy to production
-          command: make deploy
+          command: NODE_OPTIONS="--no-experimental-fetch" make deploy
 
 workflows:
   version: 2

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --max-http-header-size=80000 server/app.js
+web: node --no-experimental-fetch --max-http-header-size=80000 server/app.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "supertest-as-promised": "^4.0.2"
       },
       "engines": {
-        "node": "16.x"
+        "node": "18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Financial-Times/next-lure-api/issues"
   },
   "engines": {
-    "node": "16.x"
+    "node": "18.x"
   },
   "homepage": "https://github.com/Financial-Times/next-lure-api#readme",
   "dependencies": {
@@ -61,6 +61,7 @@
     }
   },
   "volta": {
-    "node": "16.14.2"
+    "node": "18.17.0",
+    "npm": "9.8.1"
   }
 }


### PR DESCRIPTION
**Description**

PR to achieve upgrade to Node v18. This is part of [migrating to Node v.18 Initiative](https://financialtimes.atlassian.net/browse/CON-2706).

In order to achieve the migration, it has been used the following [migration script](https://github.com/Financial-Times/platform-scripts/tree/7c571c9e8e5e452e6cf16f36fc44b0769c71551f/upgrade-node-18).